### PR TITLE
Kushagra/eng 2533

### DIFF
--- a/adapters/gbm-auctions-new/bid.ts
+++ b/adapters/gbm-auctions-new/bid.ts
@@ -78,7 +78,6 @@ export async function handleBid(
   // Additional safety check - don't emit if currencyErc20Address is null/undefined
   if (!currencyErc20Address) {
     console.warn(`No valid currency address for auction ${saleID}, skipping bid`);
-    console.log(bidder, bidamount, saleID, bidIndex, log);
     return;
   }
 

--- a/adapters/gbm-auctions-new/claim.ts
+++ b/adapters/gbm-auctions-new/claim.ts
@@ -29,8 +29,6 @@ export async function handleClaim(
     return;
   }
 
-  console.log(winner, saleID, saleID.toString());
-
   // Emit the bid action
   await emitFns.action.action({
     key: md5Hash(`${log.txRef}${log.logIndex}`),

--- a/adapters/morphomarkets/feeds/morphomarkets.ts
+++ b/adapters/morphomarkets/feeds/morphomarkets.ts
@@ -72,14 +72,6 @@ export const morphomarketsFeed = defineFeedHandler({
       // Therefore return USD per *unit*, not per whole share:
       // pricePerUnit = pricePerShare / 1e18
 
-      console.log({
-        underlyingPrice: underlyingPrice.toString(),
-        index: index.toString(),
-        indexScale: indexScale.toString(),
-        pricePerUnit: pricePerUnit.toString(),
-        pricePerUnitNumber: pricePerUnit,
-      });
-
       return pricePerUnit;
     } catch (error) {
       logger.warn(`Failed to price Morpho Markets asset ${asset.key}: ${String(error)}`);

--- a/adapters/morphomarkets/feeds/morphomarkets.ts
+++ b/adapters/morphomarkets/feeds/morphomarkets.ts
@@ -3,7 +3,8 @@ import Big from 'big.js';
 import { z } from 'zod';
 import { logger } from '../../../src/utils/logger.ts';
 import { SCALE } from '../consts.ts'; // e.g. 1e18 as a bigint
-
+Big.DP = 50;
+Big.RM = 1;
 // 1 whole share = 1e18 share units
 const SHARE_SCALE = new Big('1000000000000000000'); // 1e18
 
@@ -23,14 +24,14 @@ export const morphomarketsFeed = defineFeedHandler({
       const lastDashIndex = assetIdentifier.lastIndexOf('-');
       if (lastDashIndex <= 0) {
         logger.warn(`Malformed morpho asset key: ${assetIdentifier}`);
-        return 0;
+        return Big(0);
       }
 
       const marketId = assetIdentifier.slice(0, lastDashIndex);
       const side = assetIdentifier.slice(lastDashIndex + 1);
       if (side !== 'supply' && side !== 'borrow') {
         logger.warn(`Unknown morpho side '${side}' for ${assetIdentifier}`);
-        return 0;
+        return Big(0);
       }
 
       // Load market data (indexes & loan token)
@@ -38,7 +39,7 @@ export const morphomarketsFeed = defineFeedHandler({
       const marketDataStr = await ctx.redis.get(marketDataKey);
       if (!marketDataStr) {
         logger.warn(`Asset data not found for ${assetIdentifier} - skipping pricing`);
-        return 0;
+        return Big(0);
       }
 
       const { loanToken, supplyIndex, borrowIndex } = JSON.parse(marketDataStr);
@@ -55,40 +56,34 @@ export const morphomarketsFeed = defineFeedHandler({
         ctx,
       );
 
-      const underlyingPrice = new Big(underlyingPriceResult?.price ?? 0);
+      const underlyingPrice = new Big(underlyingPriceResult?.price.toString() ?? '0');
       if (underlyingPrice.lte(0)) {
         logger.warn(`Underlying price 0 for ${loanToken} (market ${marketId})`);
-        return 0;
+        return Big(0);
       }
 
       // tokensPerShare = index / SCALE
       // pricePerShare (USD per 1 share) = underlyingPrice * tokensPerShare
-      const pricePerShare = underlyingPrice
-        .mul(index)
-        .div(indexScale)
-        .div(10 ** 18);
-
+      const denom = indexScale.mul(SHARE_SCALE); // 1e36
+      const pricePerUnit = underlyingPrice.mul(index).div(denom);
       // IMPORTANT:
       // Your composite asset reports decimals = 0 (no normalization),
       // but amounts are in *share units* (1 share = 1e18 units).
       // Therefore return USD per *unit*, not per whole share:
       // pricePerUnit = pricePerShare / 1e18
 
-      console.log(
-        'pricePerShare',
-        pricePerShare.toString(),
-        pricePerShare.toNumber(),
-        pricePerShare,
-      );
-      console.log('underlyingPrice', underlyingPrice.toString());
-      console.log('index', index.toString());
-      console.log('indexScale', indexScale.toString());
-      console.log('underlyingPrice', underlyingPrice.toString());
+      console.log({
+        underlyingPrice: underlyingPrice.toString(),
+        index: index.toString(),
+        indexScale: indexScale.toString(),
+        pricePerUnit: pricePerUnit.toString(),
+        pricePerUnitNumber: pricePerUnit,
+      });
 
-      return Number(pricePerShare.toString());
+      return pricePerUnit;
     } catch (error) {
       logger.warn(`Failed to price Morpho Markets asset ${asset.key}: ${String(error)}`);
-      return 0;
+      return Big(0);
     }
   },
 });

--- a/adapters/morphomarkets/market.ts
+++ b/adapters/morphomarkets/market.ts
@@ -5,6 +5,7 @@ import type { manifest } from './index.ts';
 import * as morphov1Abi from './abi/morphov1.ts';
 import { Redis } from 'ioredis';
 import { SCALE } from './consts.ts';
+import { logger } from '../../src/utils/logger.ts';
 
 function deriveIndexFromEvent(assets: bigint, shares: bigint): bigint {
   if (shares === 0n) return SCALE;
@@ -19,11 +20,6 @@ export async function handleMarket(
   redis: Redis,
   sqdRpcCtx: SqdRpcCtx,
 ): Promise<void> {
-  // DEBUG: Log all incoming events
-  console.log('handleMarket called with topic0:', log.topic0);
-  console.log('Supply topic:', morphov1Abi.events.Supply.topic);
-  console.log('Repay topic:', morphov1Abi.events.Repay.topic);
-
   const configuredMarketId = (instance as any).assetSelectors?.marketId?.toLowerCase();
 
   if (!configuredMarketId) {
@@ -33,19 +29,15 @@ export async function handleMarket(
 
   // Route to appropriate handler based on event type
   if (log.topic0 === morphov1Abi.events.Supply.topic) {
-    console.log('Processing SUPPLY event');
     await handleSupply(log, emitFns, instance, configuredMarketId, redis);
   } else if (log.topic0 === morphov1Abi.events.Withdraw.topic) {
-    console.log('Processing WITHDRAW event');
     await handleWithdraw(log, emitFns, instance, configuredMarketId, redis);
   } else if (log.topic0 === morphov1Abi.events.Borrow.topic) {
-    console.log('Processing BORROW event');
     await handleBorrow(log, emitFns, instance, configuredMarketId, redis);
   } else if (log.topic0 === morphov1Abi.events.Repay.topic) {
-    console.log('Processing REPAY event');
     await handleRepay(log, emitFns, instance, configuredMarketId, redis);
   } else {
-    console.log('UNKNOWN EVENT TYPE:', log.topic0);
+    logger.warn('UNKNOWN EVENT TYPE:', log.topic0);
   }
   await emitFns.position.reprice({ trackableInstance: instance });
 }
@@ -176,7 +168,7 @@ async function handleBorrow(
     return;
   }
 
-  console.log('onBehalf', onBehalf, log.height, 'borrow');
+  logger.debug('onBehalf', onBehalf, log.height, 'borrow');
 
   const marketDataKey = `morpho:market:${marketId.toLowerCase()}`;
   const marketDataStr = await redis.get(marketDataKey);
@@ -192,10 +184,6 @@ async function handleBorrow(
   marketData.borrowIndex = borrowIndex.toString();
   await redis.set(marketDataKey, JSON.stringify(marketData));
 
-  console.log('emitting borrow', onBehalf, log.height, 'borrow');
-  if (onBehalf.toLowerCase() === '0xcf01ceaf894a27025b241dd58cf4366b14a1f9f8') {
-    console.log('🚨 TARGET USER - about to emit balanceDelta');
-  }
   await emitFns.position.balanceDelta({
     activity: 'hold',
     user: onBehalf.toLowerCase(),

--- a/adapters/morphomarkets/tests/config/morphomarkets.absinthe.json
+++ b/adapters/morphomarkets/tests/config/morphomarkets.absinthe.json
@@ -16,7 +16,7 @@
   "network": {
     "chainId": 1,
     "gatewayUrl": "https://v2.archive.subsquid.io/network/ethereum-mainnet",
-    "rpcUrl": "https://mainnet.infura.io/v3/e5b6ee7b35c3402a8fc12263c715a1f8",
+    "rpcUrl": "${env:RPC_URL}",
     "finality": 75
   },
   "range": {

--- a/adapters/morphov1vaults/feeds/morphov1vaults.ts
+++ b/adapters/morphov1vaults/feeds/morphov1vaults.ts
@@ -53,7 +53,7 @@ export const morphov1vaultsFeed = defineFeedHandler({
         const marketDataStr = await ctx.redis.get(marketDataKey);
         if (!marketDataStr) {
           logger.warn(`Vault ${vaultAddress} not found in Redis - skipping pricing`);
-          return 0;
+          return Big(0);
         }
 
         const marketData = JSON.parse(marketDataStr);
@@ -86,17 +86,24 @@ export const morphov1vaultsFeed = defineFeedHandler({
       // Calculate vault share price
       // 1 share (1e18) = marketIndex assets (in underlying's decimals)
       // share_price = asset_price * (marketIndex / 10^underlyingDecimals)
-      const sharePrice = new Big(underlyingPriceResult.price)
+      const sharePrice = new Big(underlyingPriceResult.price.toString())
         .mul(marketIndex.toString())
         .div(10 ** vaultConfig.underlyingDecimals)
         .div(10 ** 18);
 
-      console.log('sharePrice', sharePrice.toString());
+      console.log(
+        'sharePrice',
+        sharePrice.toString(),
+        underlyingPriceResult.price.toString(),
+        marketIndex.toString(),
+        vaultConfig.underlyingDecimals,
+        Number(sharePrice.toString()),
+      );
 
-      return Number(sharePrice.toString());
+      return sharePrice;
     } catch (error) {
       logger.warn(`Failed to price Morpho V1 Vault ${asset.key}:`, error);
-      return 0;
+      return Big(0);
     }
   },
 });

--- a/adapters/morphov1vaults/feeds/morphov1vaults.ts
+++ b/adapters/morphov1vaults/feeds/morphov1vaults.ts
@@ -68,20 +68,12 @@ export const morphov1vaultsFeed = defineFeedHandler({
       // Get conversion rate: 1 share (1e18) → X assets (dynamic data, not cached)
       const marketIndex = await vaultContract.convertToAssets(BigInt(1e18));
 
-      console.log(
-        'marketIndex',
-        marketIndex,
-        'vaultConfig.underlyingAssetAddress',
-        vaultConfig.underlyingAssetAddress,
-      );
       // Recursively price the underlying asset using the config
       const underlyingPriceResult = await resolve(
         { type: 'erc20', address: vaultConfig.underlyingAssetAddress },
         config.underlyingAsset,
         ctx,
       );
-
-      console.log('underlyingPriceResult', underlyingPriceResult);
 
       // Calculate vault share price
       // 1 share (1e18) = marketIndex assets (in underlying's decimals)
@@ -90,15 +82,6 @@ export const morphov1vaultsFeed = defineFeedHandler({
         .mul(marketIndex.toString())
         .div(10 ** vaultConfig.underlyingDecimals)
         .div(10 ** 18);
-
-      console.log(
-        'sharePrice',
-        sharePrice.toString(),
-        underlyingPriceResult.price.toString(),
-        marketIndex.toString(),
-        vaultConfig.underlyingDecimals,
-        Number(sharePrice.toString()),
-      );
 
       return sharePrice;
     } catch (error) {

--- a/adapters/morphov2vaults/feeds/morphov2vaults.ts
+++ b/adapters/morphov2vaults/feeds/morphov2vaults.ts
@@ -67,22 +67,12 @@ export const morphov2vaultsFeed = defineFeedHandler({
 
       // Get conversion rate: 1 share (1e18) → X assets (dynamic data, not cached)
       const marketIndex = await vaultContract.convertToAssets(BigInt(1e18));
-
-      console.log(
-        'marketIndex',
-        marketIndex,
-        'vaultConfig.underlyingAssetAddress',
-        vaultConfig.underlyingAssetAddress,
-      );
       // Recursively price the underlying asset using the config
       const underlyingPriceResult = await resolve(
         { type: 'erc20', address: vaultConfig.underlyingAssetAddress },
         config.underlyingAsset,
         ctx,
       );
-
-      console.log('underlyingPriceResult', underlyingPriceResult);
-
       // Calculate vault share price
       // 1 share (1e18) = marketIndex assets (in underlying's decimals)
       // share_price = asset_price * (marketIndex / 10^underlyingDecimals)
@@ -90,8 +80,6 @@ export const morphov2vaultsFeed = defineFeedHandler({
         .mul(marketIndex.toString())
         .div(10 ** vaultConfig.underlyingDecimals)
         .div(10 ** 18);
-
-      console.log('sharePrice', sharePrice.toString());
 
       return sharePrice;
     } catch (error) {

--- a/adapters/morphov2vaults/feeds/morphov2vaults.ts
+++ b/adapters/morphov2vaults/feeds/morphov2vaults.ts
@@ -53,7 +53,7 @@ export const morphov2vaultsFeed = defineFeedHandler({
         const marketDataStr = await ctx.redis.get(marketDataKey);
         if (!marketDataStr) {
           logger.warn(`Vault ${vaultAddress} not found in Redis - skipping pricing`);
-          return 0;
+          return Big(0);
         }
 
         const marketData = JSON.parse(marketDataStr);
@@ -86,17 +86,17 @@ export const morphov2vaultsFeed = defineFeedHandler({
       // Calculate vault share price
       // 1 share (1e18) = marketIndex assets (in underlying's decimals)
       // share_price = asset_price * (marketIndex / 10^underlyingDecimals)
-      const sharePrice = new Big(underlyingPriceResult.price)
+      const sharePrice = new Big(underlyingPriceResult.price.toString())
         .mul(marketIndex.toString())
         .div(10 ** vaultConfig.underlyingDecimals)
         .div(10 ** 18);
 
       console.log('sharePrice', sharePrice.toString());
 
-      return Number(sharePrice.toString());
+      return sharePrice;
     } catch (error) {
       logger.warn(`Failed to price Morpho V1 Vault ${asset.key}:`, error);
-      return 0;
+      return Big(0);
     }
   },
 });

--- a/adapters/uniswap-v2/feeds/nav.ts
+++ b/adapters/uniswap-v2/feeds/nav.ts
@@ -1,7 +1,7 @@
 // Uniswap V2 LP NAV pricing handler
 // Calculates Net Asset Value of LP tokens by pricing underlying reserves
 
-import { defineFeedHandler, FeedSchema } from '../../../src/types/asset.ts';
+import { defineFeedHandler, FeedSchema, FeedSchemaCoingecko } from '../../../src/types/asset.ts';
 import Big from 'big.js';
 import * as univ2Abi from '../abi/uniswap-v2.ts';
 import { logger } from '../../../src/utils/logger.ts';
@@ -30,8 +30,8 @@ export const univ2navFeed = defineFeedHandler({
   name: 'univ2nav',
   acceptsAssetType: 'erc20',
   configSchema: z.object({
-    token0: FeedSchema,
-    token1: FeedSchema,
+    token0: FeedSchemaCoingecko,
+    token1: FeedSchemaCoingecko,
   }),
   handler: async ({ asset, config, ctx, resolve }) => {
     try {
@@ -105,7 +105,7 @@ export const univ2navFeed = defineFeedHandler({
 
       return lpTokenPrice;
     } catch (error) {
-      logger.warn(`Failed to price Uniswap V2 LP token ${asset.address}:`, error);
+      console.error(`Failed to price Uniswap V2 LP token ${asset.address}:`, error);
       return Big(0);
     }
   },

--- a/adapters/uniswap-v2/feeds/nav.ts
+++ b/adapters/uniswap-v2/feeds/nav.ts
@@ -88,12 +88,12 @@ export const univ2navFeed = defineFeedHandler({
       // Value of token0 reserves in USD
       const token0Value = new Big(reserve0.toString())
         .div(Math.pow(10, price0Result.metadata.decimals))
-        .mul(price0Result.price);
+        .mul(price0Result.price.toString());
 
       // Value of token1 reserves in USD
       const token1Value = new Big(reserve1.toString())
         .div(Math.pow(10, price1Result.metadata.decimals))
-        .mul(price1Result.price);
+        .mul(price1Result.price.toString());
 
       // Total pool value in USD
       const totalPoolValue = token0Value.plus(token1Value);
@@ -103,10 +103,10 @@ export const univ2navFeed = defineFeedHandler({
         new Big(totalSupply.toString()).div(Math.pow(10, poolConfig.lpDecimals)),
       );
 
-      return Number(lpTokenPrice.toString());
+      return lpTokenPrice;
     } catch (error) {
       logger.warn(`Failed to price Uniswap V2 LP token ${asset.address}:`, error);
-      return 0;
+      return Big(0);
     }
   },
 });

--- a/adapters/uniswap-v2/lp.ts
+++ b/adapters/uniswap-v2/lp.ts
@@ -17,20 +17,30 @@ export async function handleLpTransfer(
     data: log.data,
   });
 
-  // Emit balance deltas for LP token transfers
-  await emitFns.position.balanceDelta({
-    user: decoded.from.toLowerCase(),
-    asset: { type: 'erc20', address: poolAddress },
-    amount: -decoded.value,
-    activity: 'hold',
-    trackableInstance: instance,
-  });
+  const fromAddress = decoded.from.toLowerCase();
+  const toAddress = decoded.to.toLowerCase();
+  const zeroAddress = '0x0000000000000000000000000000000000000000';
 
-  await emitFns.position.balanceDelta({
-    user: decoded.to.toLowerCase(),
-    asset: { type: 'erc20', address: poolAddress },
-    amount: decoded.value,
-    activity: 'hold',
-    trackableInstance: instance,
-  });
+  // Only emit if from/to are not zero address and not the pool address
+  if (fromAddress !== zeroAddress && fromAddress !== poolAddress.toLowerCase()) {
+    await emitFns.position.balanceDelta({
+      user: fromAddress,
+      asset: { type: 'erc20', address: poolAddress },
+      amount: -decoded.value,
+      activity: 'hold',
+      trackableInstance: instance,
+    });
+    await emitFns.position.reprice({ trackableInstance: instance });
+  }
+
+  if (toAddress !== zeroAddress && toAddress !== poolAddress.toLowerCase()) {
+    await emitFns.position.balanceDelta({
+      user: toAddress,
+      asset: { type: 'erc20', address: poolAddress },
+      amount: decoded.value,
+      activity: 'hold',
+      trackableInstance: instance,
+    });
+    await emitFns.position.reprice({ trackableInstance: instance });
+  }
 }

--- a/adapters/uniswap-v2/tests/config/uniswap-v2-hemi.absinthe.json
+++ b/adapters/uniswap-v2/tests/config/uniswap-v2-hemi.absinthe.json
@@ -1,0 +1,72 @@
+{
+  "chainArch": "evm",
+  "flushInterval": "2h",
+  "redisUrl": "${env:REDIS_URL}",
+  "sinkConfig": {
+    "sinks": [
+      {
+        "sinkType": "csv",
+        "path": "uniswap-v2.csv"
+      }
+    ]
+  },
+  "network": {
+    "chainId": 43111,
+    "gatewayUrl": "https://v2.archive.subsquid.io/network/hemi-mainnet",
+    "rpcUrl": "https://rpc.hemi.network/rpc",
+    "finality": 75
+  },
+  "range": {
+    "fromBlock": 1451314,
+    "toBlock": 2524976
+  },
+  "adapterConfig": {
+    "adapterId": "uniswap-v2",
+    "config": {
+      "swap": [
+        {
+          "params": {
+            "poolAddress": "0x0621bae969de9c153835680f158f481424c0720a"
+          },
+          "assetSelectors": {
+            "swapLegAddress": "0xAA40c0c7644e0b2B224509571e10ad20d9C4ef28"
+          },
+          "pricing": {
+            "kind": "coingecko",
+            "id": "bitcoin"
+          }
+        },
+        {
+          "params": {
+            "poolAddress": "0x0621bae969de9c153835680f158f481424c0720a"
+          },
+          "assetSelectors": {
+            "swapLegAddress": "0xad11a8BEb98bbf61dbb1aa0F6d6F2ECD87b35afA"
+          },
+          "pricing": {
+            "kind": "coingecko",
+            "id": "usd-coin"
+          }
+        }
+      ],
+      "lp": [
+        {
+          "params": {
+            "poolAddress": "0x0621bae969de9c153835680f158f481424c0720a"
+          },
+          "pricing": {
+            "kind": "univ2nav",
+            "token0": {
+              "kind": "coingecko",
+              "id": "bitcoin"
+            },
+            "token1": {
+              "kind": "coingecko",
+              "id": "usd-coin"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/adapters/uniswap-v3/feeds/lp.ts
+++ b/adapters/uniswap-v3/feeds/lp.ts
@@ -208,7 +208,7 @@ export const univ3lpFeed = defineFeedHandler({
               error,
             );
             // Return 0 for invalid/non-existent positions
-            return 0;
+            return Big(0);
           }
         } else {
           logger.debug('🔍 UNIV3LP: Using cached position metadata from handler cache');
@@ -243,7 +243,7 @@ export const univ3lpFeed = defineFeedHandler({
         logger.warn(
           `🔍 UNIV3LP: No liquidity found for ${assetKey} at height ${ctx.block.header.height}`,
         );
-        return 0;
+        return Big(0);
       }
 
       const L = new Big(fetchedL);
@@ -252,7 +252,7 @@ export const univ3lpFeed = defineFeedHandler({
       // If liquidity is 0, position has no value
       if (L.eq(0)) {
         logger.debug('🔍 UNIV3LP: Liquidity is 0, returning 0');
-        return 0;
+        return Big(0);
       }
 
       // 3) Read pool price state (slot0) - try Redis first, fallback to contract
@@ -324,19 +324,19 @@ export const univ3lpFeed = defineFeedHandler({
         );
         logger.debug('🔍 UNIV3LP: Known token resolved:', { price: knownResolved.price });
 
-        if (!knownResolved || knownResolved.price == null || !(knownResolved.price > 0)) {
+        if (!knownResolved || knownResolved.price == null || !knownResolved.price.gt(0)) {
           logger.error('🔍 UNIV3LP: Failed to resolve known token price');
-          return 0;
+          return Big(0);
         }
 
         // 7) Derive the missing token price from sqrtPriceX96
         const P01 = priceToken0InToken1(sqrtPriceX96, d0, d1); // token1 per token0
         let p0usd: Big, p1usd: Big;
         if (knownIs0) {
-          p0usd = Big(knownResolved.price);
+          p0usd = Big(knownResolved.price.toString());
           p1usd = p0usd.div(P01); // USD1 = USD0 / (token1 per token0)
         } else {
-          p1usd = Big(knownResolved.price);
+          p1usd = Big(knownResolved.price.toString());
           p0usd = p1usd.times(P01); // USD0 = USD1 * (token1 per token0)
         }
 
@@ -360,15 +360,15 @@ export const univ3lpFeed = defineFeedHandler({
         });
 
         logger.debug('🔍 UNIV3LP: Handler completed successfully, returning:', valueUsd.toNumber());
-        return valueUsd.toNumber();
+        return valueUsd;
       } catch (error) {
         logger.error(`🔍 UNIV3LP: Failed to price position ${tokenId}:`, error);
         logger.debug('🔍 UNIV3LP: Handler failed, returning 0');
-        return 0;
+        return Big(0);
       }
     } catch (error) {
       logger.error(`🔍 UNIV3LP: Outer error for asset ${asset.tokenId}:`, error);
-      return 0;
+      return Big(0);
     }
   },
 });

--- a/projects/printr/src/abi/T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint/events.ts
+++ b/projects/printr/src/abi/T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint/events.ts
@@ -1,0 +1,29 @@
+import {event} from '../abi.support'
+import {DeployTelecoinEvent as DeployTelecoinEvent_, PrintTelecoinEvent as PrintTelecoinEvent_, TeleportWithLzEvent as TeleportWithLzEvent_} from './types'
+
+export type DeployTelecoinEvent = DeployTelecoinEvent_
+
+export const DeployTelecoinEvent = event(
+    {
+        d8: '0x85d9c1e533c3f862',
+    },
+    DeployTelecoinEvent_,
+)
+
+export type PrintTelecoinEvent = PrintTelecoinEvent_
+
+export const PrintTelecoinEvent = event(
+    {
+        d8: '0xca07d422cd476f8b',
+    },
+    PrintTelecoinEvent_,
+)
+
+export type TeleportWithLzEvent = TeleportWithLzEvent_
+
+export const TeleportWithLzEvent = event(
+    {
+        d8: '0xa6aa3d7de0a6e362',
+    },
+    TeleportWithLzEvent_,
+)

--- a/projects/printr/src/abi/T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint/index.ts
+++ b/projects/printr/src/abi/T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint/index.ts
@@ -1,0 +1,5 @@
+export * as instructions from './instructions'
+export * as events from './events'
+export * as types from './types'
+
+export const programId = 'T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint'

--- a/projects/printr/src/abi/T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint/instructions.ts
+++ b/projects/printr/src/abi/T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint/instructions.ts
@@ -1,0 +1,1004 @@
+import {address, binary, fixedArray, struct, u8, unit} from '@subsquid/borsh'
+import {instruction} from '../abi.support'
+import {EstimateTeleportWithLzParams, LzReceiveParams, PrintrConfigParams, SetPeerConfParams, SetTelecoinTeleportConfParams, SqrtBitshiftedPrice, SwapIntent, TelecoinId, TelecoinParams, TelecoinParamsCompact, TeleportWithLzParams} from './types'
+
+export interface AuthorizedSpendAllQuote {
+    maxPrice: SqrtBitshiftedPrice
+    extraSeed: Uint8Array
+}
+
+export const authorizedSpendAllQuote = instruction(
+    {
+        d8: '0x376aee0e98f6ba81',
+    },
+    {
+        /**
+         * This is a Printr PDA.
+         * You can see the expected seed in the [Self::apply] static function.
+         */
+        authorizor: 0,
+        authorizorWallet: 1,
+        /**
+         * The user performing the swap
+         */
+        swapPayer: 2,
+        /**
+         * This is the account that funds the graduation process.
+         * 
+         */
+        swapPrintrAuthority: 3,
+        swapInputWallet: 4,
+        /**
+         * The mint of this token account determines what's being sold, whether telecoin or quote.
+         */
+        swapOutputWallet: 5,
+        swapTelecoinMint: 6,
+        swapQuoteMint: 7,
+        swapDbcPoolAuthority: 8,
+        swapDbcConfig: 9,
+        swapDbcPool: 10,
+        swapDbcTelecoinVault: 11,
+        swapDbcQuoteVault: 12,
+        swapDbcEventAuthority: 13,
+        swapDbcMigrationMetadata: 14,
+        swapDammPrintrPartnerConfig: 15,
+        swapDammPool: 16,
+        swapDammPoolAuthority: 17,
+        swapDammTelecoinVault: 18,
+        swapDammQuoteVault: 19,
+        swapDammPositionNftMint: 20,
+        swapDammPositionNftAccount: 21,
+        swapDammPosition: 22,
+        swapDammEventAuthority: 23,
+        /**
+         * We'll need this to init the mint and init the token account.
+         */
+        swapTelecoinTokenProgram: 24,
+        /**
+         * We'll need this to do transfers.
+         */
+        swapQuoteTokenProgram: 25,
+        /**
+         * The DBC program that abstracts the bonding curve logic.
+         */
+        swapDbcProgram: 26,
+        /**
+         * The DAMM V2 program that abstracts the AMM logic.
+         */
+        swapDammProgram: 27,
+        /**
+         * New accounts, native transfers, etc.
+         */
+        swapSystemProgram: 28,
+    },
+    struct({
+        maxPrice: SqrtBitshiftedPrice,
+        extraSeed: binary,
+    }),
+)
+
+export interface CancelAuthorizedSpendAllQuote {
+    maxPrice: SqrtBitshiftedPrice
+    telecoinMint: string
+    extraSeed: Uint8Array
+}
+
+export const cancelAuthorizedSpendAllQuote = instruction(
+    {
+        d8: '0xa701b845f2abf0cf',
+    },
+    {
+        /**
+         * This is a Printr PDA.
+         * You can see the expected seed in the [Self::apply] static function.
+         */
+        authorizor: 0,
+        /**
+         * The SPL token account associated with the authorizor.
+         */
+        authorizorWallet: 1,
+        /**
+         * The quote mint that was meant to be swapped against the telecoin token.
+         */
+        quoteMint: 2,
+        /**
+         * The authorizor's recipient can cancel their own swap order.
+         */
+        recipient: 3,
+        /**
+         * The recipient's wallet if applicable.
+         */
+        recipientWallet: 4,
+        /**
+         * Allows us to swap.
+         */
+        quoteTokenProgram: 5,
+        /**
+         * We need to transfer.
+         */
+        systemProgram: 6,
+    },
+    struct({
+        maxPrice: SqrtBitshiftedPrice,
+        telecoinMint: address,
+        extraSeed: binary,
+    }),
+)
+
+export type ClaimDammFees = undefined
+
+export const claimDammFees = instruction(
+    {
+        d8: '0xddc0a723b46e6b72',
+    },
+    {
+        payer: 0,
+        printrAuthority: 1,
+        printrConfig: 2,
+        telecoinMint: 3,
+        /**
+         * The quote mint is the token that will be used to buy telecoin tokens.
+         */
+        quoteMint: 4,
+        /**
+         * Stores all protocol quote fees.
+         */
+        printrProtocolQuoteFeeVault: 5,
+        /**
+         * Stores all protocol telecoin fees.
+         */
+        stakingWallet: 6,
+        /**
+         * The dev config stores information about the dev and must match the damm pool.
+         * 
+         * We know this is the right dev config because its seed matches the telecoin mint which in
+         * turn matches the dammv2 pool.
+         */
+        devConfig: 7,
+        /**
+         * Stores all quote fees across all telecoins for all devs.
+         * How much a dev can claim is tracked in their `DevConfig`.
+         */
+        devsQuoteFeeVault: 8,
+        dammPositionNftAccount: 9,
+        dammPosition: 10,
+        dammPoolAuthority: 11,
+        dammPool: 12,
+        dammBaseVault: 13,
+        dammQuoteVault: 14,
+        dammEventAuthority: 15,
+        /**
+         * We'll need this to transfer.
+         */
+        telecoinTokenProgram: 16,
+        /**
+         * For the telecoin fees.
+         */
+        associatedTokenProgram: 17,
+        /**
+         * We'll need this to do transfers.
+         */
+        quoteTokenProgram: 18,
+        /**
+         * Necessary for creating new accounts.
+         */
+        systemProgram: 19,
+        /**
+         * The DAMM program that abstracts the bonding curve logic.
+         */
+        dammV2Program: 20,
+    },
+    unit,
+)
+
+export type ClaimDbcFees = undefined
+
+export const claimDbcFees = instruction(
+    {
+        d8: '0xa2de805a3b732282',
+    },
+    {
+        payer: 0,
+        printrAuthority: 1,
+        printrConfig: 2,
+        telecoinMint: 3,
+        /**
+         * The quote mint is the token that is be used to buy telecoin tokens.
+         */
+        quoteMint: 4,
+        /**
+         * Stores all protocol fees.
+         */
+        printrProtocolQuoteFeeVault: 5,
+        /**
+         * Therefore any old telecoin wallet will do, it will not be used.
+         */
+        anyTelecoinWallet: 6,
+        printrIntermediaryAuthority: 7,
+        /**
+         * Useful only for $wSOL quote token.
+         * We will collect some fee amount to support smart graduation in swap ix.
+         */
+        printrIntermediaryQuoteWallet: 8,
+        /**
+         * 
+         */
+        dbcConfig: 9,
+        dbcPoolAuthority: 10,
+        dbcPool: 11,
+        dbcBaseVault: 12,
+        dbcQuoteVault: 13,
+        dbcEventAuthority: 14,
+        /**
+         * The dev config stores information about the dev and must match the DBC pool.
+         * 
+         * We know this is the right dev config because its seed matches the telecoin mint which in
+         * turn matches the dbc pool.
+         */
+        devConfig: 15,
+        /**
+         * Stores all quote fees across all telecoins for all devs.
+         * How much a dev can claim is tracked in their DevConfig.
+         */
+        devsQuoteFeeVault: 16,
+        /**
+         * We'll need this to transfer.
+         */
+        telecoinTokenProgram: 17,
+        /**
+         * We'll need this to do transfers.
+         */
+        quoteTokenProgram: 18,
+        /**
+         * Used to create dev's telecoin ATA.
+         */
+        associatedTokenProgram: 19,
+        /**
+         * Necessary for creating new accounts.
+         */
+        systemProgram: 20,
+        /**
+         * The DBC program that abstracts the bonding curve logic.
+         */
+        dbcProgram: 21,
+    },
+    unit,
+)
+
+export type ClaimPrintrAuthorityLamports = undefined
+
+export const claimPrintrAuthorityLamports = instruction(
+    {
+        d8: '0x340e8c7229690030',
+    },
+    {
+        admin: 0,
+        printrAuthority: 1,
+        /**
+         * Necessary for creating new accounts.
+         */
+        systemProgram: 2,
+    },
+    unit,
+)
+
+export interface CreatePrintrConfig {
+    params: PrintrConfigParams
+}
+
+export const createPrintrConfig = instruction(
+    {
+        d8: '0xa0bf42d4056a14d7',
+    },
+    {
+        admin: 0,
+        printrTeamTreasuryAuthority: 1,
+        printrGrowthFundAuthority: 2,
+        printrBuybackAuthority: 3,
+        printrStakingAuthority: 4,
+        /**
+         * We use `init_if_needed` purposefully.
+         * Call this ix again to update the config.
+         */
+        printrConfig: 5,
+        /**
+         * Necessary for creating new accounts.
+         */
+        systemProgram: 6,
+    },
+    struct({
+        params: PrintrConfigParams,
+    }),
+)
+
+export interface DeployTelecoin {
+    telecoinParamsCompact: TelecoinParamsCompact
+}
+
+export const deployTelecoin = instruction(
+    {
+        d8: '0x04f814017d3f0f00',
+    },
+    {
+        /**
+         * Creating a launch is a permission-less operation.
+         * This could be a Printr user or a BE.
+         */
+        payer: 0,
+        printrAuthority: 1,
+        devConfig: 2,
+        /**
+         * This is the telecoin mint which we initialize according to the telecoin params.
+         */
+        telecoinMint: 3,
+        /**
+         * We'll need this to init the mint.
+         */
+        telecoinTokenProgram: 4,
+        /**
+         * Necessary for creating new accounts.
+         */
+        systemProgram: 5,
+        eventAuthority: 6,
+        program: 7,
+    },
+    struct({
+        telecoinParamsCompact: TelecoinParamsCompact,
+    }),
+)
+
+export interface DeployTelecoin2 {
+    telecoinParams: TelecoinParams
+}
+
+export const deployTelecoin2 = instruction(
+    {
+        d8: '0x259b36ecbae1c989',
+    },
+    {
+        /**
+         * Creating a launch is a permission-less operation.
+         * This could be a Printr user or a BE.
+         */
+        payer: 0,
+        printrAuthority: 1,
+        devConfig: 2,
+        /**
+         * This is the telecoin mint which we initialize according to the telecoin params.
+         */
+        telecoinMint: 3,
+        /**
+         * We'll need this to init the mint.
+         */
+        telecoinTokenProgram: 4,
+        /**
+         * Necessary for creating new accounts.
+         */
+        systemProgram: 5,
+        eventAuthority: 6,
+        program: 7,
+    },
+    struct({
+        telecoinParams: TelecoinParams,
+    }),
+)
+
+export type DistributeDevQuoteFees = undefined
+
+export const distributeDevQuoteFees = instruction(
+    {
+        d8: '0xe82300a5c3ca3a0b',
+    },
+    {
+        payer: 0,
+        printrAuthority: 1,
+        printrConfig: 2,
+        /**
+         * The quote mint is the token that is be used to buy telecoin tokens.
+         */
+        quoteMint: 3,
+        telecoinMint: 4,
+        /**
+         * Stores all quote fees across all telecoins for all devs.
+         * How much a dev can claim is tracked in their dev config.
+         */
+        devsQuoteFeeVault: 5,
+        /**
+         * The dev config stores information about how much a dev can claim.
+         * The existence of this account implies that the telecoin mint was created by Printr.
+         */
+        devConfig: 6,
+        dev: 7,
+        devQuoteWallet: 8,
+        dbcPool: 9,
+        dbcConfig: 10,
+        /**
+         * We'll need this to do transfers.
+         */
+        quoteTokenProgram: 11,
+        /**
+         * Used to create dev's quote ATA.
+         */
+        associatedTokenProgram: 12,
+        /**
+         * Necessary for creating new accounts.
+         */
+        systemProgram: 13,
+    },
+    unit,
+)
+
+export type DistributeProtocolQuoteFees = undefined
+
+export const distributeProtocolQuoteFees = instruction(
+    {
+        d8: '0xebdfd13b49885177',
+    },
+    {
+        printrConfig: 0,
+        /**
+         * The quote mint is the token that is be used to buy telecoin tokens.
+         */
+        quoteMint: 1,
+        /**
+         * Stores all protocol fees.
+         */
+        printrProtocolQuoteFeeVault: 2,
+        printrTeamTreasuryQuoteWallet: 3,
+        printrGrowthFundQuoteWallet: 4,
+        printrBuybackQuoteWallet: 5,
+        /**
+         * We'll need this to do transfers.
+         */
+        quoteTokenProgram: 6,
+        /**
+         * Necessary for creating new accounts.
+         */
+        systemProgram: 7,
+    },
+    unit,
+)
+
+export interface EstimateSwap {
+    params: SwapIntent
+}
+
+export const estimateSwap = instruction(
+    {
+        d8: '0xdbc4b7523b25a63b',
+    },
+    {
+        dbcConfig: 0,
+        dbcPool: 1,
+        /**
+         * Might be uninitialized if the pool is not yet graduated.
+         */
+        dammPool: 2,
+    },
+    struct({
+        params: SwapIntent,
+    }),
+)
+
+export interface EstimateTeleportWithLz {
+    params: EstimateTeleportWithLzParams
+}
+
+export const estimateTeleportWithLz = instruction(
+    {
+        d8: '0x0b8da67699ff3e84',
+    },
+    {
+        peer: 0,
+    },
+    struct({
+        params: EstimateTeleportWithLzParams,
+    }),
+)
+
+export interface LzReceive {
+    params: LzReceiveParams
+}
+
+export const lzReceive = instruction(
+    {
+        d8: '0x08b3786d2176bd50',
+    },
+    {
+        /**
+         * The LZ executor.
+         */
+        payer: 0,
+        /**
+         * Represents where did the message come from.
+         */
+        peer: 1,
+        /**
+         * If this account does not exist then the provided peer must be set as a default peer.
+         * Otherwise we parse this account's configuration and assert it's been upheld.
+         */
+        telecoinTeleportConfig: 2,
+        /**
+         * Global Printr telecoin mint authority
+         */
+        printrAuthority: 3,
+        /**
+         * We'll mint these tokens.
+         * 
+         */
+        telecoinMint: 4,
+        recipient: 5,
+        recipientDestinationTelecoinWallet: 6,
+        /**
+         * Telecoin mint is always token program 2022.
+         */
+        telecoinTokenProgram: 7,
+        /**
+         * In case we need to create the ATA
+         */
+        associatedTokenProgram: 8,
+        /**
+         * In case we need to create the ATA
+         */
+        systemProgram: 9,
+    },
+    struct({
+        params: LzReceiveParams,
+    }),
+)
+
+export interface LzReceiveTypes {
+    params: LzReceiveParams
+}
+
+export const lzReceiveTypes = instruction(
+    {
+        d8: '0xdd11f69ff8801f60',
+    },
+    {
+    },
+    struct({
+        params: LzReceiveParams,
+    }),
+)
+
+export interface LzSetPeer {
+    peerAddress: Array<number>
+}
+
+export const lzSetPeer = instruction(
+    {
+        d8: '0xc77b5174d031d5e8',
+    },
+    {
+        /**
+         * Printr staff.
+         */
+        admin: 0,
+        peer: 1,
+        lzOappRegistry: 2,
+        endpointEmitCpiEventAuthority: 3,
+        endpointProgram: 4,
+        systemProgram: 5,
+    },
+    struct({
+        peerAddress: fixedArray(u8, 32),
+    }),
+)
+
+export interface PrintTelecoin {
+    telecoinParamsCompact: TelecoinParamsCompact
+}
+
+export const printTelecoin = instruction(
+    {
+        d8: '0xd61e0466cf496c23',
+    },
+    {
+        /**
+         * Creating a launch is a permission-less operation.
+         * This could be a Printr user or a BE.
+         */
+        payer: 0,
+        printrAuthority: 1,
+        devConfig: 2,
+        /**
+         * This is the telecoin mint which we initialize according to the telecoin params in the
+         * Meteora CPI.
+         * 
+         */
+        telecoinMint: 3,
+        /**
+         * The quote mint is the token that will be used to buy telecoin tokens.
+         */
+        quoteMint: 4,
+        /**
+         * When a telecoin is printed we perform an initial buy on behalf of the dev.
+         * 
+         * There are three options how the initial buy can happen:
+         * 1. No deposit PDA
+         * 2. Deposit PDA of native $SOL
+         * 3. Deposit PDA with an associated token account.
+         * 
+         * See `DepositPda` enum for more details.
+         * 
+         */
+        initialBuyAuthority: 5,
+        initialBuySource: 6,
+        devOnSolana: 7,
+        /**
+         * Associated token account cannot exist because we've just created the telecoin mint.
+         * Will not be initialized if initial spend is zero.
+         * 
+         */
+        devDestinationTelecoinWallet: 8,
+        /**
+         * We'll init the config first.
+         * 
+         */
+        dbcConfig: 9,
+        dbcPoolAuthority: 10,
+        /**
+         * The bonding curve state, initialized after the config.
+         * 
+         */
+        dbcPool: 11,
+        dbcTelecoinVault: 12,
+        dbcQuoteVault: 13,
+        dbcEventAuthority: 14,
+        /**
+         * If provided then we create a migration metadata account for the DBC pool.
+         * 
+         */
+        dbcMigrationMetadata: 15,
+        /**
+         * We'll need this to init the mint and init the token account.
+         */
+        telecoinTokenProgram: 16,
+        /**
+         * We'll need this to do transfers.
+         */
+        quoteTokenProgram: 17,
+        /**
+         * Used to create dev's telecoin ATA.
+         */
+        associatedTokenProgram: 18,
+        /**
+         * Necessary for creating new accounts.
+         */
+        systemProgram: 19,
+        /**
+         * The DBC program that abstracts the bonding curve logic.
+         */
+        dbcProgram: 20,
+        eventAuthority: 21,
+        program: 22,
+    },
+    struct({
+        telecoinParamsCompact: TelecoinParamsCompact,
+    }),
+)
+
+export interface PrintTelecoin2 {
+    telecoinParams: TelecoinParams
+}
+
+export const printTelecoin2 = instruction(
+    {
+        d8: '0xa63c262bee2002a0',
+    },
+    {
+        /**
+         * Creating a launch is a permission-less operation.
+         * This could be a Printr user or a BE.
+         */
+        payer: 0,
+        printrAuthority: 1,
+        devConfig: 2,
+        /**
+         * This is the telecoin mint which we initialize according to the telecoin params in the
+         * Meteora CPI.
+         * 
+         */
+        telecoinMint: 3,
+        /**
+         * The quote mint is the token that will be used to buy telecoin tokens.
+         */
+        quoteMint: 4,
+        /**
+         * When a telecoin is printed we perform an initial buy on behalf of the dev.
+         * 
+         * There are three options how the initial buy can happen:
+         * 1. No deposit PDA
+         * 2. Deposit PDA of native $SOL
+         * 3. Deposit PDA with an associated token account.
+         * 
+         * See `DepositPda` enum for more details.
+         * 
+         */
+        initialBuyAuthority: 5,
+        initialBuySource: 6,
+        devOnSolana: 7,
+        /**
+         * Associated token account cannot exist because we've just created the telecoin mint.
+         * Will not be initialized if initial spend is zero.
+         * 
+         */
+        devDestinationTelecoinWallet: 8,
+        /**
+         * We'll init the config first.
+         * 
+         */
+        dbcConfig: 9,
+        dbcPoolAuthority: 10,
+        /**
+         * The bonding curve state, initialized after the config.
+         * 
+         */
+        dbcPool: 11,
+        dbcTelecoinVault: 12,
+        dbcQuoteVault: 13,
+        dbcEventAuthority: 14,
+        /**
+         * If provided then we create a migration metadata account for the DBC pool.
+         * 
+         */
+        dbcMigrationMetadata: 15,
+        /**
+         * We'll need this to init the mint and init the token account.
+         */
+        telecoinTokenProgram: 16,
+        /**
+         * We'll need this to do transfers.
+         */
+        quoteTokenProgram: 17,
+        /**
+         * Used to create dev's telecoin ATA.
+         */
+        associatedTokenProgram: 18,
+        /**
+         * Necessary for creating new accounts.
+         */
+        systemProgram: 19,
+        /**
+         * The DBC program that abstracts the bonding curve logic.
+         */
+        dbcProgram: 20,
+        eventAuthority: 21,
+        program: 22,
+    },
+    struct({
+        telecoinParams: TelecoinParams,
+    }),
+)
+
+export interface SetPeerConf {
+    params: SetPeerConfParams
+}
+
+export const setPeerConf = instruction(
+    {
+        d8: '0x51d35198d4993a47',
+    },
+    {
+        /**
+         * Printr staff.
+         */
+        admin: 0,
+        peer: 1,
+    },
+    struct({
+        params: SetPeerConfParams,
+    }),
+)
+
+export interface SetTelecoinTeleportConf {
+    telecoinId: TelecoinId
+    params: SetTelecoinTeleportConfParams
+}
+
+export const setTelecoinTeleportConf = instruction(
+    {
+        d8: '0x642f3d94c68a3e31',
+    },
+    {
+        payer: 0,
+        /**
+         * Printr staff.
+         */
+        admin: 1,
+        telecoinTeleportConfig: 2,
+        systemProgram: 3,
+    },
+    struct({
+        telecoinId: TelecoinId,
+        params: SetTelecoinTeleportConfParams,
+    }),
+)
+
+export interface SpendAllQuoteNoGraduation {
+    maxPrice: SqrtBitshiftedPrice
+}
+
+export const spendAllQuoteNoGraduation = instruction(
+    {
+        d8: '0xc6aad9f53b49723c',
+    },
+    {
+        /**
+         * The entity performing the swap.
+         * Owner of the input token account.
+         * 
+         * If the quote token is $wSOL then we transfer everything from this account to the
+         * intermediary token account.
+         */
+        payer: 0,
+        printrIntermediaryAuthority: 1,
+        /**
+         * To support post hooks with native $SOL we need to create an intermediate ATA for the quote
+         * token.
+         * All the quote tokens will be transferred to this account first before being swapped.
+         * The account is not closed so that it can be reused in the future without paying rent.
+         */
+        printrIntermediaryQuoteWallet: 2,
+        /**
+         * We will use everything that's in this token account to buy as much telecoin as possible.
+         * 
+         * Can be none for $wSOL quote if wrapping is needed.
+         */
+        inputQuoteWallet: 3,
+        recipient: 4,
+        recipientQuoteWallet: 5,
+        /**
+         * The owner of the output account will not match the payer for a posthook ix.
+         * 
+         */
+        outputTelecoinWallet: 6,
+        telecoinMint: 7,
+        quoteMint: 8,
+        dbcPoolAuthority: 9,
+        dbcConfig: 10,
+        dbcPool: 11,
+        dbcTelecoinVault: 12,
+        dbcQuoteVault: 13,
+        dbcEventAuthority: 14,
+        dammPool: 15,
+        dammPoolAuthority: 16,
+        dammTelecoinVault: 17,
+        dammQuoteVault: 18,
+        dammEventAuthority: 19,
+        /**
+         * We'll need this to init the mint and init the token account.
+         */
+        telecoinTokenProgram: 20,
+        /**
+         * We'll need this to do transfers.
+         */
+        quoteTokenProgram: 21,
+        /**
+         * The DBC program that abstracts the bonding curve logic.
+         */
+        dbcProgram: 22,
+        /**
+         * The DAMM V2 program that abstracts the AMM logic.
+         */
+        dammProgram: 23,
+        /**
+         * Used to create ATA if needed.
+         */
+        associatedTokenProgram: 24,
+        /**
+         * We might need to refill the input token account with $wSOL.
+         */
+        systemProgram: 25,
+    },
+    struct({
+        maxPrice: SqrtBitshiftedPrice,
+    }),
+)
+
+export interface Swap {
+    params: SwapIntent
+}
+
+export const swap = instruction(
+    {
+        d8: '0xf8c69e91e17587c8',
+    },
+    {
+        /**
+         * The user performing the swap
+         */
+        payer: 0,
+        /**
+         * This is the account that funds the graduation process.
+         * 
+         */
+        printrAuthority: 1,
+        inputWallet: 2,
+        /**
+         * The mint of this token account determines what's being sold, whether telecoin or quote.
+         */
+        outputWallet: 3,
+        telecoinMint: 4,
+        quoteMint: 5,
+        dbcPoolAuthority: 6,
+        dbcConfig: 7,
+        dbcPool: 8,
+        dbcTelecoinVault: 9,
+        dbcQuoteVault: 10,
+        dbcEventAuthority: 11,
+        dbcMigrationMetadata: 12,
+        dammPrintrPartnerConfig: 13,
+        dammPool: 14,
+        dammPoolAuthority: 15,
+        dammTelecoinVault: 16,
+        dammQuoteVault: 17,
+        dammPositionNftMint: 18,
+        dammPositionNftAccount: 19,
+        dammPosition: 20,
+        dammEventAuthority: 21,
+        /**
+         * We'll need this to init the mint and init the token account.
+         */
+        telecoinTokenProgram: 22,
+        /**
+         * We'll need this to do transfers.
+         */
+        quoteTokenProgram: 23,
+        /**
+         * The DBC program that abstracts the bonding curve logic.
+         */
+        dbcProgram: 24,
+        /**
+         * The DAMM V2 program that abstracts the AMM logic.
+         */
+        dammProgram: 25,
+        /**
+         * New accounts, native transfers, etc.
+         */
+        systemProgram: 26,
+    },
+    struct({
+        params: SwapIntent,
+    }),
+)
+
+export interface TeleportWithLz {
+    params: TeleportWithLzParams
+}
+
+export const teleportWithLz = instruction(
+    {
+        d8: '0xa679e9087d28b32f',
+    },
+    {
+        /**
+         * This is the user that wants to send telecoin tokens.
+         */
+        payer: 0,
+        /**
+         * The telecoin mint that we burn here.
+         */
+        telecoinMint: 1,
+        /**
+         * If this account does not exist then the provided peer must be set as a default peer.
+         * Otherwise we parse this account's configuration and assert it's been upheld.
+         */
+        telecoinTeleportConfig: 2,
+        peer: 3,
+        /**
+         * Where to burn from.
+         */
+        userSourceTelecoinWallet: 4,
+        /**
+         * Needed to burn telecoin tokens.
+         */
+        telecoinTokenProgram: 5,
+        eventAuthority: 6,
+        program: 7,
+    },
+    struct({
+        params: TeleportWithLzParams,
+    }),
+)

--- a/projects/printr/src/abi/T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint/types.ts
+++ b/projects/printr/src/abi/T8HsGYv7sMk3kTnyaRqZrbRPuntYzdh12evXBkprint/types.ts
@@ -1,0 +1,937 @@
+import {Codec, address, array, binary, bool, fixedArray, option, struct, sum, tuple, u128, u16, u32, u64, u8, unit} from '@subsquid/borsh'
+
+export interface BaseFeeConfig {
+    cliffFeeNumerator: bigint
+    secondFactor: bigint
+    thirdFactor: bigint
+    firstFactor: number
+    baseFeeMode: number
+    padding0: Array<number>
+}
+
+export const BaseFeeConfig: Codec<BaseFeeConfig> = struct({
+    cliffFeeNumerator: u64,
+    secondFactor: u64,
+    thirdFactor: u64,
+    firstFactor: u16,
+    baseFeeMode: u8,
+    padding0: fixedArray(u8, 5),
+})
+
+/**
+ * Represents basis points (bps) as a wrapper around a `u16`.
+ * 1 bps = 0.01%
+ * 10_000 bps = 100%
+ */
+export type Bps = [
+    number,
+]
+
+/**
+ * Represents basis points (bps) as a wrapper around a `u16`.
+ * 1 bps = 0.01%
+ * 10_000 bps = 100%
+ */
+export const Bps: Codec<Bps> = tuple([
+    u16,
+])
+
+/**
+ * Stores the protocol version that the telecoin was created with.
+ */
+export type PrintrProtocolVersion = [
+    number,
+]
+
+/**
+ * Stores the protocol version that the telecoin was created with.
+ */
+export const PrintrProtocolVersion: Codec<PrintrProtocolVersion> = tuple([
+    u8,
+])
+
+/**
+ * Printr's Token ID is a hash of the ABI-encoded telecoin params.
+ */
+export type TelecoinId = [
+    Array<number>,
+]
+
+/**
+ * Printr's Token ID is a hash of the ABI-encoded telecoin params.
+ */
+export const TelecoinId: Codec<TelecoinId> = tuple([
+    fixedArray(u8, 32),
+])
+
+/**
+ * Some Printr related details about the deploy.
+ */
+export interface DeployTelecoinEvent {
+    protocolVersion: PrintrProtocolVersion
+    telecoinId: TelecoinId
+    devOnSolana: string
+}
+
+/**
+ * Some Printr related details about the deploy.
+ */
+export const DeployTelecoinEvent: Codec<DeployTelecoinEvent> = struct({
+    protocolVersion: PrintrProtocolVersion,
+    telecoinId: TelecoinId,
+    devOnSolana: address,
+})
+
+/**
+ * A token amount in its smallest denomination as seen in a token account.
+ */
+export interface TokenAmount {
+    amount: bigint
+}
+
+/**
+ * A token amount in its smallest denomination as seen in a token account.
+ */
+export const TokenAmount: Codec<TokenAmount> = struct({
+    amount: u64,
+})
+
+/**
+ * Configuration for a dev of a telecoin token.
+ */
+export interface DevConfig {
+    devWallet: string
+    protocolVersion: PrintrProtocolVersion
+    telecoinId: TelecoinId
+    devQuoteFee: TokenAmount
+    _padding: Array<number>
+}
+
+/**
+ * Configuration for a dev of a telecoin token.
+ */
+export const DevConfig: Codec<DevConfig> = struct({
+    devWallet: address,
+    protocolVersion: PrintrProtocolVersion,
+    telecoinId: TelecoinId,
+    devQuoteFee: TokenAmount,
+    _padding: fixedArray(u8, 8),
+})
+
+export interface DynamicFeeConfig {
+    initialized: number
+    padding: Array<number>
+    maxVolatilityAccumulator: number
+    variableFeeControl: number
+    binStep: number
+    filterPeriod: number
+    decayPeriod: number
+    reductionFactor: number
+    padding2: Array<number>
+    binStepU128: bigint
+}
+
+export const DynamicFeeConfig: Codec<DynamicFeeConfig> = struct({
+    initialized: u8,
+    padding: fixedArray(u8, 7),
+    maxVolatilityAccumulator: u32,
+    variableFeeControl: u32,
+    binStep: u16,
+    filterPeriod: u16,
+    decayPeriod: u16,
+    reductionFactor: u16,
+    padding2: fixedArray(u8, 8),
+    binStepU128: u128,
+})
+
+/**
+ * This is a sqrt and bitshifted price ready to be compared to Meteora prices.
+ */
+export interface SqrtBitshiftedPrice {
+    price: bigint
+}
+
+/**
+ * This is a sqrt and bitshifted price ready to be compared to Meteora prices.
+ */
+export const SqrtBitshiftedPrice: Codec<SqrtBitshiftedPrice> = struct({
+    price: u128,
+})
+
+export interface SwapEstimate {
+    actualInput: TokenAmount
+    inputFee: TokenAmount
+    outputFee: TokenAmount
+    output: TokenAmount
+    nextPrice: SqrtBitshiftedPrice
+    currentPrice: SqrtBitshiftedPrice
+}
+
+export const SwapEstimate: Codec<SwapEstimate> = struct({
+    actualInput: TokenAmount,
+    inputFee: TokenAmount,
+    outputFee: TokenAmount,
+    output: TokenAmount,
+    nextPrice: SqrtBitshiftedPrice,
+    currentPrice: SqrtBitshiftedPrice,
+})
+
+/**
+ * This is the returned value from this ix.
+ */
+export interface EstimateSwapOutput {
+    estimate: SwapEstimate
+    whichRemainingAccountsAreOwnedBySystemProgram: Array<boolean>
+}
+
+/**
+ * This is the returned value from this ix.
+ */
+export const EstimateSwapOutput: Codec<EstimateSwapOutput> = struct({
+    estimate: SwapEstimate,
+    whichRemainingAccountsAreOwnedBySystemProgram: array(bool),
+})
+
+/**
+ * Parameters for the [TeleportWithLz] instruction.
+ */
+export interface EstimateTeleportWithLzParams {
+    messageLen: number
+    lzOptions: Uint8Array
+    lzDestinationEndpointId: number
+}
+
+/**
+ * Parameters for the [TeleportWithLz] instruction.
+ */
+export const EstimateTeleportWithLzParams: Codec<EstimateTeleportWithLzParams> = struct({
+    messageLen: u16,
+    lzOptions: binary,
+    lzDestinationEndpointId: u32,
+})
+
+/**
+ * Fee claiming endpoints return how much fees were claimed - in total - for each token.
+ */
+export interface FeesClaimed {
+    inTelecoin: TokenAmount
+    inQuote: TokenAmount
+}
+
+/**
+ * Fee claiming endpoints return how much fees were claimed - in total - for each token.
+ */
+export const FeesClaimed: Codec<FeesClaimed> = struct({
+    inTelecoin: TokenAmount,
+    inQuote: TokenAmount,
+})
+
+export interface LiquidityDistributionConfig {
+    sqrtPrice: bigint
+    liquidity: bigint
+}
+
+export const LiquidityDistributionConfig: Codec<LiquidityDistributionConfig> = struct({
+    sqrtPrice: u128,
+    liquidity: u128,
+})
+
+export interface LockedVestingConfig {
+    amountPerPeriod: bigint
+    cliffDurationFromMigrationTime: bigint
+    frequency: bigint
+    numberOfPeriod: bigint
+    cliffUnlockAmount: bigint
+    _padding: bigint
+}
+
+export const LockedVestingConfig: Codec<LockedVestingConfig> = struct({
+    amountPerPeriod: u64,
+    cliffDurationFromMigrationTime: u64,
+    frequency: u64,
+    numberOfPeriod: u64,
+    cliffUnlockAmount: u64,
+    _padding: u64,
+})
+
+/**
+ * same to anchor_lang::prelude::AccountMeta
+ */
+export interface LzAccount {
+    pubkey: string
+    isSigner: boolean
+    isWritable: boolean
+}
+
+/**
+ * same to anchor_lang::prelude::AccountMeta
+ */
+export const LzAccount: Codec<LzAccount> = struct({
+    pubkey: address,
+    isSigner: bool,
+    isWritable: bool,
+})
+
+export interface LzReceiveParams {
+    srcEid: number
+    sender: Array<number>
+    nonce: bigint
+    guid: Array<number>
+    message: Uint8Array
+    extraData: Uint8Array
+}
+
+export const LzReceiveParams: Codec<LzReceiveParams> = struct({
+    srcEid: u32,
+    sender: fixedArray(u8, 32),
+    nonce: u64,
+    guid: fixedArray(u8, 32),
+    message: binary,
+    extraData: binary,
+})
+
+/**
+ * A peer in omnichain network is a connection living on another chain,
+ * typically a smart contract.
+ * 
+ * A peer is authorized by the Printr staff to send and receive messages
+ * authoritatively.
+ * This suggests a reciprocal relationship between the two peers.
+ * 
+ * To trust a message we must validate that it was sent by a peer.
+ * Validation is done by relaying networks such as Axelar or LayerZero.
+ * Acts as a connection to another chain.
+ */
+export interface Peer {
+    bump: number
+    address: Array<number>
+    isLzEnabled: boolean
+    isLzDefault: boolean
+}
+
+/**
+ * A peer in omnichain network is a connection living on another chain,
+ * typically a smart contract.
+ * 
+ * A peer is authorized by the Printr staff to send and receive messages
+ * authoritatively.
+ * This suggests a reciprocal relationship between the two peers.
+ * 
+ * To trust a message we must validate that it was sent by a peer.
+ * Validation is done by relaying networks such as Axelar or LayerZero.
+ * Acts as a connection to another chain.
+ */
+export const Peer: Codec<Peer> = struct({
+    bump: u8,
+    address: fixedArray(u8, 32),
+    isLzEnabled: bool,
+    isLzDefault: bool,
+})
+
+export interface PoolFeesConfig {
+    baseFee: BaseFeeConfig
+    dynamicFee: DynamicFeeConfig
+    padding0: Array<bigint>
+    padding1: Array<number>
+    protocolFeePercent: number
+    referralFeePercent: number
+}
+
+export const PoolFeesConfig: Codec<PoolFeesConfig> = struct({
+    baseFee: BaseFeeConfig,
+    dynamicFee: DynamicFeeConfig,
+    padding0: fixedArray(u64, 5),
+    padding1: fixedArray(u8, 6),
+    protocolFeePercent: u8,
+    referralFeePercent: u8,
+})
+
+export interface PoolConfig {
+    quoteMint: string
+    feeClaimer: string
+    leftoverReceiver: string
+    poolFees: PoolFeesConfig
+    collectFeeMode: number
+    migrationOption: number
+    activationType: number
+    tokenDecimal: number
+    version: number
+    tokenType: number
+    quoteTokenFlag: number
+    partnerLockedLpPercentage: number
+    partnerLpPercentage: number
+    creatorLockedLpPercentage: number
+    creatorLpPercentage: number
+    migrationFeeOption: number
+    fixedTokenSupplyFlag: number
+    creatorTradingFeePercentage: number
+    tokenUpdateAuthority: number
+    migrationFeePercentage: number
+    creatorMigrationFeePercentage: number
+    _padding0: Array<number>
+    swapBaseAmount: bigint
+    migrationQuoteThreshold: bigint
+    migrationBaseThreshold: bigint
+    migrationSqrtPrice: bigint
+    lockedVestingConfig: LockedVestingConfig
+    preMigrationTokenSupply: bigint
+    postMigrationTokenSupply: bigint
+    migratedCollectFeeMode: number
+    migratedDynamicFee: number
+    migratedPoolFeeBps: number
+    _padding1: Array<number>
+    _padding2: bigint
+    sqrtStartPrice: bigint
+    curve: Array<LiquidityDistributionConfig>
+}
+
+export const PoolConfig: Codec<PoolConfig> = struct({
+    quoteMint: address,
+    feeClaimer: address,
+    leftoverReceiver: address,
+    poolFees: PoolFeesConfig,
+    collectFeeMode: u8,
+    migrationOption: u8,
+    activationType: u8,
+    tokenDecimal: u8,
+    version: u8,
+    tokenType: u8,
+    quoteTokenFlag: u8,
+    partnerLockedLpPercentage: u8,
+    partnerLpPercentage: u8,
+    creatorLockedLpPercentage: u8,
+    creatorLpPercentage: u8,
+    migrationFeeOption: u8,
+    fixedTokenSupplyFlag: u8,
+    creatorTradingFeePercentage: u8,
+    tokenUpdateAuthority: u8,
+    migrationFeePercentage: u8,
+    creatorMigrationFeePercentage: u8,
+    _padding0: fixedArray(u8, 7),
+    swapBaseAmount: u64,
+    migrationQuoteThreshold: u64,
+    migrationBaseThreshold: u64,
+    migrationSqrtPrice: u128,
+    lockedVestingConfig: LockedVestingConfig,
+    preMigrationTokenSupply: u64,
+    postMigrationTokenSupply: u64,
+    migratedCollectFeeMode: u8,
+    migratedDynamicFee: u8,
+    migratedPoolFeeBps: u16,
+    _padding1: fixedArray(u8, 12),
+    _padding2: u128,
+    sqrtStartPrice: u128,
+    curve: fixedArray(LiquidityDistributionConfig, 20),
+})
+
+export interface PoolMetrics {
+    totalProtocolBaseFee: bigint
+    totalProtocolQuoteFee: bigint
+    totalTradingBaseFee: bigint
+    totalTradingQuoteFee: bigint
+}
+
+export const PoolMetrics: Codec<PoolMetrics> = struct({
+    totalProtocolBaseFee: u64,
+    totalProtocolQuoteFee: u64,
+    totalTradingBaseFee: u64,
+    totalTradingQuoteFee: u64,
+})
+
+/**
+ * Some Printr related details about the launch on top of meteora events.
+ */
+export interface PrintTelecoinEvent {
+    protocolVersion: PrintrProtocolVersion
+    telecoinId: TelecoinId
+    quoteMint: string
+    devOnSolana: string
+}
+
+/**
+ * Some Printr related details about the launch on top of meteora events.
+ */
+export const PrintTelecoinEvent: Codec<PrintTelecoinEvent> = struct({
+    protocolVersion: PrintrProtocolVersion,
+    telecoinId: TelecoinId,
+    quoteMint: address,
+    devOnSolana: address,
+})
+
+/**
+ * Configuration struct holding the public keys for various Printr program wallets.
+ * 
+ * BPS shares must add to 100%.
+ * 
+ * # Fields
+ * - `growth_fund_authority`: Public key for the growth fund wallet.
+ * - `buyback_authority`: Public key for the buyback wallet.
+ * - `team_treasury_authority`: Public key for the team treasury wallet.
+ * - `staking_authority`: Public key for the staking wallet which collects telecoin fees.
+ * 
+ * # Authority
+ * 
+ * This account is an authority over several token account vaults that hold protocol and dev fees.
+ */
+export interface PrintrConfig {
+    growthFundAuthority: string
+    buybackAuthority: string
+    teamTreasuryAuthority: string
+    stakingAuthority: string
+    growthFundShare: Bps
+    buybackShare: Bps
+    teamTreasuryShare: Bps
+    devShare: Bps
+    _padding: Array<number>
+}
+
+/**
+ * Configuration struct holding the public keys for various Printr program wallets.
+ * 
+ * BPS shares must add to 100%.
+ * 
+ * # Fields
+ * - `growth_fund_authority`: Public key for the growth fund wallet.
+ * - `buyback_authority`: Public key for the buyback wallet.
+ * - `team_treasury_authority`: Public key for the team treasury wallet.
+ * - `staking_authority`: Public key for the staking wallet which collects telecoin fees.
+ * 
+ * # Authority
+ * 
+ * This account is an authority over several token account vaults that hold protocol and dev fees.
+ */
+export const PrintrConfig: Codec<PrintrConfig> = struct({
+    growthFundAuthority: address,
+    buybackAuthority: address,
+    teamTreasuryAuthority: address,
+    stakingAuthority: address,
+    growthFundShare: Bps,
+    buybackShare: Bps,
+    teamTreasuryShare: Bps,
+    devShare: Bps,
+    _padding: fixedArray(u8, 2),
+})
+
+/**
+ * BPS shares that must add up to 10_000.
+ */
+export interface PrintrConfigParams {
+    devShare: Bps
+    growthFundShare: Bps
+    buybackShare: Bps
+    teamTreasuryShare: Bps
+}
+
+/**
+ * BPS shares that must add up to 10_000.
+ */
+export const PrintrConfigParams: Codec<PrintrConfigParams> = struct({
+    devShare: Bps,
+    growthFundShare: Bps,
+    buybackShare: Bps,
+    teamTreasuryShare: Bps,
+})
+
+/**
+ * Parameters for the [SetPeerConf] instruction.
+ */
+export interface SetPeerConfParams {
+    enableLz?: boolean | undefined
+    setAsDefault?: boolean | undefined
+}
+
+/**
+ * Parameters for the [SetPeerConf] instruction.
+ */
+export const SetPeerConfParams: Codec<SetPeerConfParams> = struct({
+    enableLz: option(bool),
+    setAsDefault: option(bool),
+})
+
+export type TeleportPathConfig_Default = undefined
+
+export const TeleportPathConfig_Default = unit
+
+export type TeleportPathConfig_Disabled = undefined
+
+export const TeleportPathConfig_Disabled = unit
+
+export type TeleportPathConfig_Peers = {
+    /**
+     * This peer can be used for teleports in any direction: mint and burn.
+     */
+    teleportAnyDirection1: string
+    /**
+     * This peer can be used for teleports in any direction: mint and burn.
+     */
+    teleportAnyDirection2: string
+    /**
+     * This peer can be used for teleports in only: mint
+     */
+    teleportInOnly: string
+}
+
+export const TeleportPathConfig_Peers = struct({
+    /**
+     * This peer can be used for teleports in any direction: mint and burn.
+     */
+    teleportAnyDirection1: address,
+    /**
+     * This peer can be used for teleports in any direction: mint and burn.
+     */
+    teleportAnyDirection2: address,
+    /**
+     * This peer can be used for teleports in only: mint
+     */
+    teleportInOnly: address,
+})
+
+/**
+ * Defines how teleports should be handled.
+ */
+export type TeleportPathConfig = 
+    | {
+        kind: 'Default'
+        value?: TeleportPathConfig_Default
+      }
+    | {
+        kind: 'Disabled'
+        value?: TeleportPathConfig_Disabled
+      }
+    | {
+        kind: 'Peers'
+        value: TeleportPathConfig_Peers
+      }
+
+/**
+ * Defines how teleports should be handled.
+ */
+export const TeleportPathConfig: Codec<TeleportPathConfig> = sum(1, {
+    Default: {
+        discriminator: 0,
+        value: TeleportPathConfig_Default,
+    },
+    Disabled: {
+        discriminator: 1,
+        value: TeleportPathConfig_Disabled,
+    },
+    Peers: {
+        discriminator: 2,
+        value: TeleportPathConfig_Peers,
+    },
+})
+
+/**
+ * Parameters for the [SetTelecoinTeleportConf] instruction.
+ */
+export interface SetTelecoinTeleportConfParams {
+    setLzPeerConfig?: TeleportPathConfig | undefined
+}
+
+/**
+ * Parameters for the [SetTelecoinTeleportConf] instruction.
+ */
+export const SetTelecoinTeleportConfParams: Codec<SetTelecoinTeleportConfParams> = struct({
+    setLzPeerConfig: option(TeleportPathConfig),
+})
+
+export type SwapIntent_SpendQuote = {
+    /**
+     * Quote amount
+     */
+    sell: TokenAmount
+    /**
+     * In Printr we apply slippage to price.
+     */
+    maxPrice: SqrtBitshiftedPrice
+}
+
+export const SwapIntent_SpendQuote = struct({
+    /**
+     * Quote amount
+     */
+    sell: TokenAmount,
+    /**
+     * In Printr we apply slippage to price.
+     */
+    maxPrice: SqrtBitshiftedPrice,
+})
+
+export type SwapIntent_SellTelecoin = {
+    /**
+     * telecoin amount
+     */
+    sell: TokenAmount
+    /**
+     * In Printr we apply slippage to price.
+     */
+    minPrice: SqrtBitshiftedPrice
+}
+
+export const SwapIntent_SellTelecoin = struct({
+    /**
+     * telecoin amount
+     */
+    sell: TokenAmount,
+    /**
+     * In Printr we apply slippage to price.
+     */
+    minPrice: SqrtBitshiftedPrice,
+})
+
+export type SwapIntent_SpendAllQuote = {
+    /**
+     * Must be equal to [printr_sdk::consts::SPEND_ALL_SPECIAL_VALUE].
+     */
+    specialValue: bigint
+    /**
+     * In Printr we apply slippage to price.
+     */
+    maxPrice: SqrtBitshiftedPrice
+}
+
+export const SwapIntent_SpendAllQuote = struct({
+    /**
+     * Must be equal to [printr_sdk::consts::SPEND_ALL_SPECIAL_VALUE].
+     */
+    specialValue: u64,
+    /**
+     * In Printr we apply slippage to price.
+     */
+    maxPrice: SqrtBitshiftedPrice,
+})
+
+/**
+ * Represents user's intent to swap tokens in Printr ecosystem.
+ * We translate this intent to specific Meteora CPIs.
+ */
+export type SwapIntent = 
+    | {
+        kind: 'SpendQuote'
+        value: SwapIntent_SpendQuote
+      }
+    | {
+        kind: 'SellTelecoin'
+        value: SwapIntent_SellTelecoin
+      }
+    | {
+        kind: 'SpendAllQuote'
+        value: SwapIntent_SpendAllQuote
+      }
+
+/**
+ * Represents user's intent to swap tokens in Printr ecosystem.
+ * We translate this intent to specific Meteora CPIs.
+ */
+export const SwapIntent: Codec<SwapIntent> = sum(1, {
+    SpendQuote: {
+        discriminator: 0,
+        value: SwapIntent_SpendQuote,
+    },
+    SellTelecoin: {
+        discriminator: 1,
+        value: SwapIntent_SellTelecoin,
+    },
+    SpendAllQuote: {
+        discriminator: 2,
+        value: SwapIntent_SpendAllQuote,
+    },
+})
+
+/**
+ * The core primitive of the Printr protocol.
+ * 
+ * These telecoin params uniquely identify a token launched with Printr.
+ */
+export interface TelecoinParams {
+    salt: Array<number>
+    devAddresses: Uint8Array
+    name: Array<number>
+    symbol: Array<number>
+    packedParams: Array<number>
+    chains: Array<Array<number>>
+    quotePairs: Array<Array<number>>
+    quotePrices: Uint8Array
+}
+
+/**
+ * The core primitive of the Printr protocol.
+ * 
+ * These telecoin params uniquely identify a token launched with Printr.
+ */
+export const TelecoinParams: Codec<TelecoinParams> = struct({
+    salt: fixedArray(u8, 32),
+    devAddresses: binary,
+    name: fixedArray(u8, 32),
+    symbol: fixedArray(u8, 32),
+    packedParams: fixedArray(u8, 32),
+    chains: array(fixedArray(u8, 32)),
+    quotePairs: array(fixedArray(u8, 32)),
+    quotePrices: binary,
+})
+
+/**
+ * On Solana we're dealing with txs size limits.
+ * Being able to compress the telecoin params into a smaller structure helps us submit smaller txs.
+ * 
+ * You can always convert this back to [TelecoinParams].
+ */
+export interface TelecoinParamsCompact {
+    version: number
+    data: Uint8Array
+}
+
+/**
+ * On Solana we're dealing with txs size limits.
+ * Being able to compress the telecoin params into a smaller structure helps us submit smaller txs.
+ * 
+ * You can always convert this back to [TelecoinParams].
+ */
+export const TelecoinParamsCompact: Codec<TelecoinParamsCompact> = struct({
+    version: u8,
+    data: binary,
+})
+
+/**
+ * Overrides default configuration for a specific telecoin with respect to omnichain transfers.
+ */
+export interface TelecoinTeleportConfig {
+    lzPeer: TeleportPathConfig
+}
+
+/**
+ * Overrides default configuration for a specific telecoin with respect to omnichain transfers.
+ */
+export const TelecoinTeleportConfig: Codec<TelecoinTeleportConfig> = struct({
+    lzPeer: TeleportPathConfig,
+})
+
+/**
+ * Event emitted by the [TeleportWithLz] instruction.
+ */
+export interface TeleportWithLzEvent {
+    guid: Array<number>
+    nonce: bigint
+    lzDestinationEndpointId: number
+    telecoinId: TelecoinId
+    destinationRecipientAddress: Array<number>
+    destinationPeerAddress: Array<number>
+    sourceUserAddress: string
+    teleporting: TokenAmount
+}
+
+/**
+ * Event emitted by the [TeleportWithLz] instruction.
+ */
+export const TeleportWithLzEvent: Codec<TeleportWithLzEvent> = struct({
+    guid: fixedArray(u8, 32),
+    nonce: u64,
+    lzDestinationEndpointId: u32,
+    telecoinId: TelecoinId,
+    destinationRecipientAddress: fixedArray(u8, 32),
+    destinationPeerAddress: fixedArray(u8, 32),
+    sourceUserAddress: address,
+    teleporting: TokenAmount,
+})
+
+/**
+ * Parameters for the [TeleportWithLz] instruction.
+ * Used to construct [OutgoingMessage].
+ */
+export interface TeleportWithLzParams {
+    toSend: TokenAmount
+    destinationRecipientAddress: Array<number>
+    telecoinId: TelecoinId
+    lamportsGas: TokenAmount
+    lzOptions: Uint8Array
+    lzDestinationEndpointId: number
+}
+
+/**
+ * Parameters for the [TeleportWithLz] instruction.
+ * Used to construct [OutgoingMessage].
+ */
+export const TeleportWithLzParams: Codec<TeleportWithLzParams> = struct({
+    toSend: TokenAmount,
+    destinationRecipientAddress: fixedArray(u8, 32),
+    telecoinId: TelecoinId,
+    lamportsGas: TokenAmount,
+    lzOptions: binary,
+    lzDestinationEndpointId: u32,
+})
+
+export interface VolatilityTracker {
+    lastUpdateTimestamp: bigint
+    padding: Array<number>
+    sqrtPriceReference: bigint
+    volatilityAccumulator: bigint
+    volatilityReference: bigint
+}
+
+export const VolatilityTracker: Codec<VolatilityTracker> = struct({
+    lastUpdateTimestamp: u64,
+    padding: fixedArray(u8, 8),
+    sqrtPriceReference: u128,
+    volatilityAccumulator: u128,
+    volatilityReference: u128,
+})
+
+export interface VirtualPool {
+    volatilityTracker: VolatilityTracker
+    config: string
+    creator: string
+    baseMint: string
+    baseVault: string
+    quoteVault: string
+    baseReserve: bigint
+    quoteReserve: bigint
+    protocolBaseFee: bigint
+    protocolQuoteFee: bigint
+    partnerBaseFee: bigint
+    partnerQuoteFee: bigint
+    sqrtPrice: bigint
+    activationPoint: bigint
+    poolType: number
+    isMigrated: number
+    isPartnerWithdrawSurplus: number
+    isProtocolWithdrawSurplus: number
+    migrationProgress: number
+    isWithdrawLeftover: number
+    isCreatorWithdrawSurplus: number
+    migrationFeeWithdrawStatus: number
+    metrics: PoolMetrics
+    finishCurveTimestamp: bigint
+    creatorBaseFee: bigint
+    creatorQuoteFee: bigint
+    _padding1: Array<bigint>
+}
+
+export const VirtualPool: Codec<VirtualPool> = struct({
+    volatilityTracker: VolatilityTracker,
+    config: address,
+    creator: address,
+    baseMint: address,
+    baseVault: address,
+    quoteVault: address,
+    baseReserve: u64,
+    quoteReserve: u64,
+    protocolBaseFee: u64,
+    protocolQuoteFee: u64,
+    partnerBaseFee: u64,
+    partnerQuoteFee: u64,
+    sqrtPrice: u128,
+    activationPoint: u64,
+    poolType: u8,
+    isMigrated: u8,
+    isPartnerWithdrawSurplus: u8,
+    isProtocolWithdrawSurplus: u8,
+    migrationProgress: u8,
+    isWithdrawLeftover: u8,
+    isCreatorWithdrawSurplus: u8,
+    migrationFeeWithdrawStatus: u8,
+    metrics: PoolMetrics,
+    finishCurveTimestamp: u64,
+    creatorBaseFee: u64,
+    creatorQuoteFee: u64,
+    _padding1: fixedArray(u64, 7),
+})

--- a/projects/printr/src/abi/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA/index.ts
+++ b/projects/printr/src/abi/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA/index.ts
@@ -1,0 +1,4 @@
+export * as instructions from './instructions'
+export * as types from './types'
+
+export const programId = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'

--- a/projects/printr/src/abi/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA/instructions.ts
+++ b/projects/printr/src/abi/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA/instructions.ts
@@ -1,0 +1,438 @@
+import {address, option, string, struct, u64, u8, unit} from '@subsquid/borsh'
+import {instruction} from '../abi.support'
+import {AuthorityType} from './types'
+
+export interface InitializeMint {
+    decimals: number
+    mintAuthority: string
+    freezeAuthority?: string | undefined
+}
+
+export const initializeMint = instruction(
+    {
+        d1: '0x00',
+    },
+    {
+        mint: 0,
+        rent: 1,
+    },
+    struct({
+        decimals: u8,
+        mintAuthority: address,
+        freezeAuthority: option(address),
+    }),
+)
+
+export type InitializeAccount = undefined
+
+export const initializeAccount = instruction(
+    {
+        d1: '0x01',
+    },
+    {
+        accountToInitialize: 0,
+        mint: 1,
+        owner: 2,
+        rentSysvar: 3,
+    },
+    unit,
+)
+
+export interface InitializeMultisig {
+    noOfSignersRequired: number
+}
+
+export const initializeMultisig = instruction(
+    {
+        d1: '0x02',
+    },
+    {
+        multisig: 0,
+        rent: 1,
+        signers: 2,
+    },
+    struct({
+        noOfSignersRequired: u8,
+    }),
+)
+
+export interface Transfer {
+    amount: bigint
+}
+
+export const transfer = instruction(
+    {
+        d1: '0x03',
+    },
+    {
+        source: 0,
+        destination: 1,
+        authority: 2,
+        signers: 3,
+    },
+    struct({
+        amount: u64,
+    }),
+)
+
+export interface Approve {
+    amount: bigint
+}
+
+export const approve = instruction(
+    {
+        d1: '0x04',
+    },
+    {
+        source: 0,
+        delegate: 1,
+        owner: 2,
+        signers: 3,
+    },
+    struct({
+        amount: u64,
+    }),
+)
+
+export type Revoke = undefined
+
+export const revoke = instruction(
+    {
+        d1: '0x05',
+    },
+    {
+        source: 0,
+        owner: 1,
+        signers: 2,
+    },
+    unit,
+)
+
+export interface SetAuthority {
+    authorityType: AuthorityType
+    newAuthority?: string | undefined
+}
+
+export const setAuthority = instruction(
+    {
+        d1: '0x06',
+    },
+    {
+        mint: 0,
+        currentAuthority: 1,
+        signers: 2,
+    },
+    struct({
+        authorityType: AuthorityType,
+        newAuthority: option(address),
+    }),
+)
+
+export interface MintTo {
+    amount: bigint
+}
+
+export const mintTo = instruction(
+    {
+        d1: '0x07',
+    },
+    {
+        mint: 0,
+        mintTo: 1,
+        mintAuthority: 2,
+        signers: 3,
+    },
+    struct({
+        amount: u64,
+    }),
+)
+
+export interface Burn {
+    amount: bigint
+}
+
+export const burn = instruction(
+    {
+        d1: '0x08',
+    },
+    {
+        burnAccount: 0,
+        mint: 1,
+        owner: 2,
+        signers: 3,
+    },
+    struct({
+        amount: u64,
+    }),
+)
+
+export type CloseAccount = undefined
+
+export const closeAccount = instruction(
+    {
+        d1: '0x09',
+    },
+    {
+        closeAccount: 0,
+        destination: 1,
+        owner: 2,
+        signers: 3,
+    },
+    unit,
+)
+
+export type FreezeAccount = undefined
+
+export const freezeAccount = instruction(
+    {
+        d1: '0x0a',
+    },
+    {
+        freezeAccount: 0,
+        mint: 1,
+        owner: 2,
+        signers: 3,
+    },
+    unit,
+)
+
+export type ThawAccount = undefined
+
+export const thawAccount = instruction(
+    {
+        d1: '0x0b',
+    },
+    {
+        thawAccount: 0,
+        mint: 1,
+        owner: 2,
+        signers: 3,
+    },
+    unit,
+)
+
+export interface TransferChecked {
+    amount: bigint
+    decimals: number
+}
+
+export const transferChecked = instruction(
+    {
+        d1: '0x0c',
+    },
+    {
+        source: 0,
+        tokenMint: 1,
+        destination: 2,
+        owner: 3,
+        signers: 4,
+    },
+    struct({
+        amount: u64,
+        decimals: u8,
+    }),
+)
+
+export interface ApproveChecked {
+    amount: bigint
+    decimals: number
+}
+
+export const approveChecked = instruction(
+    {
+        d1: '0x0d',
+    },
+    {
+        source: 0,
+        tokenMint: 1,
+        delegate: 2,
+        owner: 3,
+        signers: 4,
+    },
+    struct({
+        amount: u64,
+        decimals: u8,
+    }),
+)
+
+export interface MintToChecked {
+    amount: bigint
+    decimals: number
+}
+
+export const mintToChecked = instruction(
+    {
+        d1: '0x0e',
+    },
+    {
+        tokenMint: 0,
+        mintTo: 1,
+        mintAuthority: 2,
+        signers: 3,
+    },
+    struct({
+        amount: u64,
+        decimals: u8,
+    }),
+)
+
+export interface BurnChecked {
+    amount: bigint
+    decimals: number
+}
+
+export const burnChecked = instruction(
+    {
+        d1: '0x0f',
+    },
+    {
+        burnAccount: 0,
+        tokenMint: 1,
+        owner: 2,
+        signers: 3,
+    },
+    struct({
+        amount: u64,
+        decimals: u8,
+    }),
+)
+
+export interface InitializeAccount2 {
+    owner: string
+}
+
+export const initializeAccount2 = instruction(
+    {
+        d1: '0x10',
+    },
+    {
+        initializeAccount: 0,
+        associatedMint: 1,
+        rentSysvar: 2,
+    },
+    struct({
+        owner: address,
+    }),
+)
+
+export type SyncNative = undefined
+
+export const syncNative = instruction(
+    {
+        d1: '0x11',
+    },
+    {
+        nativeTokenAccount: 0,
+    },
+    unit,
+)
+
+export interface InitializeAccount3 {
+    owner: string
+}
+
+export const initializeAccount3 = instruction(
+    {
+        d1: '0x12',
+    },
+    {
+        initializeAccount: 0,
+        associatedMint: 1,
+    },
+    struct({
+        owner: address,
+    }),
+)
+
+export interface InitializeMultisig2 {
+    m: number
+}
+
+export const initializeMultisig2 = instruction(
+    {
+        d1: '0x13',
+    },
+    {
+        initializeAccount: 0,
+        signers: 1,
+    },
+    struct({
+        m: u8,
+    }),
+)
+
+export interface InitializeMint2 {
+    decimals: number
+    mintAuthority: string
+    freezeAuthority?: string | undefined
+}
+
+export const initializeMint2 = instruction(
+    {
+        d1: '0x14',
+    },
+    {
+        mint: 0,
+    },
+    struct({
+        decimals: u8,
+        mintAuthority: address,
+        freezeAuthority: option(address),
+    }),
+)
+
+export type GetAccountDataSize = undefined
+
+export const getAccountDataSize = instruction(
+    {
+        d1: '0x15',
+    },
+    {
+        mint: 0,
+    },
+    unit,
+)
+
+export type InitializeImmutableOwner = undefined
+
+export const initializeImmutableOwner = instruction(
+    {
+        d1: '0x16',
+    },
+    {
+        initializeAccount: 0,
+    },
+    unit,
+)
+
+export interface AmountToUiAmount {
+    amount: bigint
+}
+
+export const amountToUiAmount = instruction(
+    {
+        d1: '0x17',
+    },
+    {
+        mint: 0,
+    },
+    struct({
+        amount: u64,
+    }),
+)
+
+export interface UiAmountToAmount {
+    uiAmount: string
+}
+
+export const uiAmountToAmount = instruction(
+    {
+        d1: '0x18',
+    },
+    {
+        mint: 0,
+    },
+    struct({
+        uiAmount: string,
+    }),
+)

--- a/projects/printr/src/abi/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA/types.ts
+++ b/projects/printr/src/abi/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA/types.ts
@@ -1,0 +1,232 @@
+import {Codec, address, bool, fixedArray, struct, sum, u64, u8, unit} from '@subsquid/borsh'
+
+export type AccountState_Uninitialized = undefined
+
+export const AccountState_Uninitialized = unit
+
+export type AccountState_Initialized = undefined
+
+export const AccountState_Initialized = unit
+
+export type AccountState_Frozen = undefined
+
+export const AccountState_Frozen = unit
+
+export type AccountState = 
+    | {
+        kind: 'Uninitialized'
+        value?: AccountState_Uninitialized
+      }
+    | {
+        kind: 'Initialized'
+        value?: AccountState_Initialized
+      }
+    | {
+        kind: 'Frozen'
+        value?: AccountState_Frozen
+      }
+
+export const AccountState: Codec<AccountState> = sum(1, {
+    Uninitialized: {
+        discriminator: 0,
+        value: AccountState_Uninitialized,
+    },
+    Initialized: {
+        discriminator: 1,
+        value: AccountState_Initialized,
+    },
+    Frozen: {
+        discriminator: 2,
+        value: AccountState_Frozen,
+    },
+})
+
+export type AuthorityType_MintTokens = undefined
+
+export const AuthorityType_MintTokens = unit
+
+export type AuthorityType_FreezeAccount = undefined
+
+export const AuthorityType_FreezeAccount = unit
+
+export type AuthorityType_AccountOwner = undefined
+
+export const AuthorityType_AccountOwner = unit
+
+export type AuthorityType_CloseAccount = undefined
+
+export const AuthorityType_CloseAccount = unit
+
+export type AuthorityType = 
+    | {
+        kind: 'MintTokens'
+        value?: AuthorityType_MintTokens
+      }
+    | {
+        kind: 'FreezeAccount'
+        value?: AuthorityType_FreezeAccount
+      }
+    | {
+        kind: 'AccountOwner'
+        value?: AuthorityType_AccountOwner
+      }
+    | {
+        kind: 'CloseAccount'
+        value?: AuthorityType_CloseAccount
+      }
+
+export const AuthorityType: Codec<AuthorityType> = sum(1, {
+    MintTokens: {
+        discriminator: 0,
+        value: AuthorityType_MintTokens,
+    },
+    FreezeAccount: {
+        discriminator: 1,
+        value: AuthorityType_FreezeAccount,
+    },
+    AccountOwner: {
+        discriminator: 2,
+        value: AuthorityType_AccountOwner,
+    },
+    CloseAccount: {
+        discriminator: 3,
+        value: AuthorityType_CloseAccount,
+    },
+})
+
+export interface MintAccount {
+    mintAuthority: 
+        | {
+            kind: 'None'
+            value?: undefined
+          }
+        | {
+            kind: 'Some'
+            value: string
+          }
+    supply: bigint
+    decimals: number
+    isInitialized: boolean
+    freezeAuthority: 
+        | {
+            kind: 'None'
+            value?: undefined
+          }
+        | {
+            kind: 'Some'
+            value: string
+          }
+}
+
+export const MintAccount: Codec<MintAccount> = struct({
+    mintAuthority: sum(4, {
+        None: {
+            discriminator: 0,
+            value: unit,
+        },
+        Some: {
+            discriminator: 1,
+            value: address,
+        },
+    }),
+    supply: u64,
+    decimals: u8,
+    isInitialized: bool,
+    freezeAuthority: sum(4, {
+        None: {
+            discriminator: 0,
+            value: unit,
+        },
+        Some: {
+            discriminator: 1,
+            value: address,
+        },
+    }),
+})
+
+export interface TokenAccount {
+    mint: string
+    owner: string
+    amount: bigint
+    delegate: 
+        | {
+            kind: 'None'
+            value?: undefined
+          }
+        | {
+            kind: 'Some'
+            value: string
+          }
+    state: AccountState
+    isNative: 
+        | {
+            kind: 'None'
+            value?: undefined
+          }
+        | {
+            kind: 'Some'
+            value: bigint
+          }
+    delegatedAmount: bigint
+    closeAuthority: 
+        | {
+            kind: 'None'
+            value?: undefined
+          }
+        | {
+            kind: 'Some'
+            value: string
+          }
+}
+
+export const TokenAccount: Codec<TokenAccount> = struct({
+    mint: address,
+    owner: address,
+    amount: u64,
+    delegate: sum(4, {
+        None: {
+            discriminator: 0,
+            value: unit,
+        },
+        Some: {
+            discriminator: 1,
+            value: address,
+        },
+    }),
+    state: AccountState,
+    isNative: sum(4, {
+        None: {
+            discriminator: 0,
+            value: unit,
+        },
+        Some: {
+            discriminator: 1,
+            value: u64,
+        },
+    }),
+    delegatedAmount: u64,
+    closeAuthority: sum(4, {
+        None: {
+            discriminator: 0,
+            value: unit,
+        },
+        Some: {
+            discriminator: 1,
+            value: address,
+        },
+    }),
+})
+
+export interface MultisigAccount {
+    numOfSignersRequired: number
+    numOfValidSignersRequired: number
+    isInitialized: boolean
+    signers: Array<string>
+}
+
+export const MultisigAccount: Codec<MultisigAccount> = struct({
+    numOfSignersRequired: u8,
+    numOfValidSignersRequired: u8,
+    isInitialized: bool,
+    signers: fixedArray(address, 11),
+})

--- a/projects/printr/src/abi/abi.support.ts
+++ b/projects/printr/src/abi/abi.support.ts
@@ -1,0 +1,249 @@
+import {Codec, GetCodecType, Src} from '@subsquid/borsh'
+import {getInstructionData} from '@subsquid/solana-stream'
+import assert from 'assert'
+
+
+export type Bytes = string
+export type Base58Bytes = string
+
+
+export function instruction<
+    D extends Discriminator,
+    A extends Record<string, number>,
+    DataCodec extends Codec<any>
+>(
+    d: D,
+    accounts: A,
+    data: DataCodec
+): DeriveInstruction<D, A, DataCodec> {
+    let ins = new Instruction(accounts, data)
+    Object.assign(ins, d)
+    return ins as any
+}
+
+
+export function event<
+    D extends Discriminator,
+    DataCodec extends Codec<any>
+>(
+    d: D,
+    data: DataCodec
+): DeriveEvent<D, DataCodec> {
+    let event = new Event(data)
+    Object.assign(event, d)
+    return event as any
+}
+
+
+type DeriveInstruction<D, A, DataCodec> = Simplify<
+    RemoveUndefined<D> &
+    Instruction<
+        {[K in keyof A]: Base58Bytes},
+        GetCodecType<DataCodec>
+    >
+>
+
+
+type DeriveEvent<D, DataCodec> = Simplify<
+    RemoveUndefined<D> &
+    Event<GetCodecType<DataCodec>>
+>
+
+
+export type Simplify<T> = {
+    [K in keyof T]: T[K]
+} & {}
+
+
+type RemoveUndefined<T> = {
+    [K in keyof T as undefined extends T[K] ? never : K]: T[K]
+}
+
+
+class Instruction<A, D> {
+    constructor(
+        private accounts: {[K in keyof A]: number},
+        private data: Codec<D>
+    ) {}
+
+    accountSelection(accounts: {[K in keyof A]?: Base58Bytes[]}): AccountSelection {
+        let selection: any = {}
+        for (let key in accounts) {
+            let idx = this.accounts[key]
+            assert(idx < 10)
+            selection['a'+idx] = accounts[key]
+        }
+        return selection
+    }
+
+    decode(ins: {
+        accounts: Base58Bytes[],
+        data: Bytes
+    }): DecodedInstruction<A, D> {
+        return {
+            accounts: this.decodeAccounts(ins.accounts),
+            data: this.decodeData(getInstructionData(ins))
+        }
+    }
+
+    decodeAccounts(accounts: Base58Bytes[]): A {
+        let result: any = {}
+        for (let key in this.accounts) {
+            result[key] = accounts[this.accounts[key]]
+        }
+        return result
+    }
+
+    decodeData(data: Uint8Array): D {
+        let src = new Src(data)
+        this.assertDiscriminator(src)
+        return this.data.decode(src)
+    }
+
+    private _assertDiscriminator?: (src: Src) => void
+
+    private assertDiscriminator(src: Src): void {
+        if (this._assertDiscriminator == null) {
+            this._assertDiscriminator = this.createDiscriminatorAssertion()
+        }
+        this._assertDiscriminator(src)
+    }
+
+    private createDiscriminatorAssertion(): (src: Src) => void {
+        let self: Discriminator = this as any
+        if (self.d8 != null) {
+            let d = new Src(decodeHex(self.d8)).u64()
+            return src => {
+                assert(d === src.u64())
+            }
+        } else if (self.d4 != null) {
+            let d = new Src(decodeHex(self.d4)).u32()
+            return src => {
+                assert(d === src.u32())
+            }
+        } else if (self.d2 != null) {
+            let d = new Src(decodeHex(self.d2)).u16()
+            return src => {
+                assert(d === src.u16())
+            }
+        } else {
+            let d = new Src(decodeHex(self.d1)).u8()
+            return src => {
+                assert(d === src.u8())
+            }
+        }
+    }
+}
+
+
+class Event<D> {
+    constructor(
+        private data: Codec<D>
+    ) {}
+
+    decode(event: {
+        msg: Bytes
+    }): D {
+        return this.decodeData(decodeHex(event.msg))
+    }
+
+    decodeData(data: Uint8Array): D {
+        let src = new Src(data)
+        this.assertDiscriminator(src)
+        return this.data.decode(src)
+    }
+
+    private _assertDiscriminator?: (src: Src) => void
+
+    private assertDiscriminator(src: Src): void {
+        if (this._assertDiscriminator == null) {
+            this._assertDiscriminator = this.createDiscriminatorAssertion()
+        }
+        this._assertDiscriminator(src)
+    }
+
+    private createDiscriminatorAssertion(): (src: Src) => void {
+        let self: Discriminator = this as any
+        if (self.d8 != null) {
+            let d = new Src(decodeHex(self.d8)).u64()
+            return src => {
+                assert(d === src.u64())
+            }
+        } else if (self.d4 != null) {
+            let d = new Src(decodeHex(self.d4)).u32()
+            return src => {
+                assert(d === src.u32())
+            }
+        } else if (self.d2 != null) {
+            let d = new Src(decodeHex(self.d2)).u16()
+            return src => {
+                assert(d === src.u16())
+            }
+        } else {
+            let d = new Src(decodeHex(self.d1)).u8()
+            return src => {
+                assert(d === src.u8())
+            }
+        }
+    }
+}
+
+
+function decodeHex(bytes: Bytes): Uint8Array {
+    return Buffer.from(bytes.slice(2), 'hex')
+}
+
+
+export interface DecodedInstruction<A, D> {
+    accounts: A
+    data: D
+}
+
+
+export type Discriminator = D1 | D2 | D4 | D8
+
+
+interface D1 {
+    d1: Bytes
+    d2?: undefined
+    d4?: undefined
+    d8?: undefined
+}
+
+
+interface D2 {
+    d1?: undefined
+    d2: Bytes
+    d4?: undefined
+    d8?: undefined
+}
+
+
+interface D4 {
+    d1?: undefined
+    d2?: undefined
+    d4: Bytes
+    d8?: undefined
+}
+
+
+interface D8 {
+    d1?: undefined
+    d2?: undefined
+    d4?: undefined
+    d8: Bytes
+}
+
+
+export interface AccountSelection {
+    a0?: Base58Bytes[]
+    a1?: Base58Bytes[]
+    a2?: Base58Bytes[]
+    a3?: Base58Bytes[]
+    a4?: Base58Bytes[]
+    a5?: Base58Bytes[]
+    a6?: Base58Bytes[]
+    a7?: Base58Bytes[]
+    a8?: Base58Bytes[]
+    a9?: Base58Bytes[]
+}

--- a/projects/printr/src/abi/pool2.ts
+++ b/projects/printr/src/abi/pool2.ts
@@ -1,0 +1,220 @@
+import * as p from '@subsquid/evm-codec'
+import { event, fun, viewFun, indexed, ContractBase } from '@subsquid/evm-abi'
+import type { EventParams as EParams, FunctionArguments, FunctionReturn } from '@subsquid/evm-abi'
+
+export const events = {
+    Burn: event("0x0c396cd989a39f4459b5fa1aed6a9a8dcdbc45908acfd67e028cd568da98982c", "Burn(address,int24,int24,uint128,uint256,uint256)", {"owner": indexed(p.address), "tickLower": indexed(p.int24), "tickUpper": indexed(p.int24), "amount": p.uint128, "amount0": p.uint256, "amount1": p.uint256}),
+    Collect: event("0x70935338e69775456a85ddef226c395fb668b63fa0115f5f20610b388e6ca9c0", "Collect(address,address,int24,int24,uint128,uint128)", {"owner": indexed(p.address), "recipient": p.address, "tickLower": indexed(p.int24), "tickUpper": indexed(p.int24), "amount0": p.uint128, "amount1": p.uint128}),
+    CollectProtocol: event("0x596b573906218d3411850b26a6b437d6c4522fdb43d2d2386263f86d50b8b151", "CollectProtocol(address,address,uint128,uint128)", {"sender": indexed(p.address), "recipient": indexed(p.address), "amount0": p.uint128, "amount1": p.uint128}),
+    Flash: event("0xbdbdb71d7860376ba52b25a5028beea23581364a40522f6bcfb86bb1f2dca633", "Flash(address,address,uint256,uint256,uint256,uint256)", {"sender": indexed(p.address), "recipient": indexed(p.address), "amount0": p.uint256, "amount1": p.uint256, "paid0": p.uint256, "paid1": p.uint256}),
+    IncreaseObservationCardinalityNext: event("0xac49e518f90a358f652e4400164f05a5d8f7e35e7747279bc3a93dbf584e125a", "IncreaseObservationCardinalityNext(uint16,uint16)", {"observationCardinalityNextOld": p.uint16, "observationCardinalityNextNew": p.uint16}),
+    Initialize: event("0x98636036cb66a9c19a37435efc1e90142190214e8abeb821bdba3f2990dd4c95", "Initialize(uint160,int24)", {"sqrtPriceX96": p.uint160, "tick": p.int24}),
+    Mint: event("0x7a53080ba414158be7ec69b987b5fb7d07dee101fe85488f0853ae16239d0bde", "Mint(address,address,int24,int24,uint128,uint256,uint256)", {"sender": p.address, "owner": indexed(p.address), "tickLower": indexed(p.int24), "tickUpper": indexed(p.int24), "amount": p.uint128, "amount0": p.uint256, "amount1": p.uint256}),
+    SetFeeProtocol: event("0xb3159fed3ddfba67bae294599eafe2d0ec98c08bb38e0e5fb87d33154b6e05aa", "SetFeeProtocol(uint32,uint32,uint32,uint32)", {"feeProtocol0Old": p.uint32, "feeProtocol1Old": p.uint32, "feeProtocol0New": p.uint32, "feeProtocol1New": p.uint32}),
+    SetLmPoolEvent: event("0x29983690a85a11696ce8a357993744f8d5a74fde14653e517cc2f8608a7235e9", "SetLmPoolEvent(address)", {"addr": p.address}),
+    Swap: event("0x19b47279256b2a23a1665c810c8d55a1758940ee09377d4f8d26497a3577dc83", "Swap(address,address,int256,int256,uint160,uint128,int24,uint128,uint128)", {"sender": indexed(p.address), "recipient": indexed(p.address), "amount0": p.int256, "amount1": p.int256, "sqrtPriceX96": p.uint160, "liquidity": p.uint128, "tick": p.int24, "protocolFeesToken0": p.uint128, "protocolFeesToken1": p.uint128}),
+}
+
+export const functions = {
+    burn: fun("0xa34123a7", "burn(int24,int24,uint128)", {"tickLower": p.int24, "tickUpper": p.int24, "amount": p.uint128}, {"amount0": p.uint256, "amount1": p.uint256}),
+    collect: fun("0x4f1eb3d8", "collect(address,int24,int24,uint128,uint128)", {"recipient": p.address, "tickLower": p.int24, "tickUpper": p.int24, "amount0Requested": p.uint128, "amount1Requested": p.uint128}, {"amount0": p.uint128, "amount1": p.uint128}),
+    collectProtocol: fun("0x85b66729", "collectProtocol(address,uint128,uint128)", {"recipient": p.address, "amount0Requested": p.uint128, "amount1Requested": p.uint128}, {"amount0": p.uint128, "amount1": p.uint128}),
+    factory: viewFun("0xc45a0155", "factory()", {}, p.address),
+    fee: viewFun("0xddca3f43", "fee()", {}, p.uint24),
+    feeGrowthGlobal0X128: viewFun("0xf3058399", "feeGrowthGlobal0X128()", {}, p.uint256),
+    feeGrowthGlobal1X128: viewFun("0x46141319", "feeGrowthGlobal1X128()", {}, p.uint256),
+    flash: fun("0x490e6cbc", "flash(address,uint256,uint256,bytes)", {"recipient": p.address, "amount0": p.uint256, "amount1": p.uint256, "data": p.bytes}, ),
+    increaseObservationCardinalityNext: fun("0x32148f67", "increaseObservationCardinalityNext(uint16)", {"observationCardinalityNext": p.uint16}, ),
+    initialize: fun("0xf637731d", "initialize(uint160)", {"sqrtPriceX96": p.uint160}, ),
+    liquidity: viewFun("0x1a686502", "liquidity()", {}, p.uint128),
+    lmPool: viewFun("0x540d4918", "lmPool()", {}, p.address),
+    maxLiquidityPerTick: viewFun("0x70cf754a", "maxLiquidityPerTick()", {}, p.uint128),
+    mint: fun("0x3c8a7d8d", "mint(address,int24,int24,uint128,bytes)", {"recipient": p.address, "tickLower": p.int24, "tickUpper": p.int24, "amount": p.uint128, "data": p.bytes}, {"amount0": p.uint256, "amount1": p.uint256}),
+    observations: viewFun("0x252c09d7", "observations(uint256)", {"_0": p.uint256}, {"blockTimestamp": p.uint32, "tickCumulative": p.int56, "secondsPerLiquidityCumulativeX128": p.uint160, "initialized": p.bool}),
+    observe: viewFun("0x883bdbfd", "observe(uint32[])", {"secondsAgos": p.array(p.uint32)}, {"tickCumulatives": p.array(p.int56), "secondsPerLiquidityCumulativeX128s": p.array(p.uint160)}),
+    positions: viewFun("0x514ea4bf", "positions(bytes32)", {"_0": p.bytes32}, {"liquidity": p.uint128, "feeGrowthInside0LastX128": p.uint256, "feeGrowthInside1LastX128": p.uint256, "tokensOwed0": p.uint128, "tokensOwed1": p.uint128}),
+    protocolFees: viewFun("0x1ad8b03b", "protocolFees()", {}, {"token0": p.uint128, "token1": p.uint128}),
+    setFeeProtocol: fun("0xb0d0d211", "setFeeProtocol(uint32,uint32)", {"feeProtocol0": p.uint32, "feeProtocol1": p.uint32}, ),
+    setLmPool: fun("0xcc7e7fa2", "setLmPool(address)", {"_lmPool": p.address}, ),
+    slot0: viewFun("0x3850c7bd", "slot0()", {}, {"sqrtPriceX96": p.uint160, "tick": p.int24, "observationIndex": p.uint16, "observationCardinality": p.uint16, "observationCardinalityNext": p.uint16, "feeProtocol": p.uint32, "unlocked": p.bool}),
+    snapshotCumulativesInside: viewFun("0xa38807f2", "snapshotCumulativesInside(int24,int24)", {"tickLower": p.int24, "tickUpper": p.int24}, {"tickCumulativeInside": p.int56, "secondsPerLiquidityInsideX128": p.uint160, "secondsInside": p.uint32}),
+    swap: fun("0x128acb08", "swap(address,bool,int256,uint160,bytes)", {"recipient": p.address, "zeroForOne": p.bool, "amountSpecified": p.int256, "sqrtPriceLimitX96": p.uint160, "data": p.bytes}, {"amount0": p.int256, "amount1": p.int256}),
+    tickBitmap: viewFun("0x5339c296", "tickBitmap(int16)", {"_0": p.int16}, p.uint256),
+    tickSpacing: viewFun("0xd0c93a7c", "tickSpacing()", {}, p.int24),
+    ticks: viewFun("0xf30dba93", "ticks(int24)", {"_0": p.int24}, {"liquidityGross": p.uint128, "liquidityNet": p.int128, "feeGrowthOutside0X128": p.uint256, "feeGrowthOutside1X128": p.uint256, "tickCumulativeOutside": p.int56, "secondsPerLiquidityOutsideX128": p.uint160, "secondsOutside": p.uint32, "initialized": p.bool}),
+    token0: viewFun("0x0dfe1681", "token0()", {}, p.address),
+    token1: viewFun("0xd21220a7", "token1()", {}, p.address),
+}
+
+export class Contract extends ContractBase {
+
+    factory() {
+        return this.eth_call(functions.factory, {})
+    }
+
+    fee() {
+        return this.eth_call(functions.fee, {})
+    }
+
+    feeGrowthGlobal0X128() {
+        return this.eth_call(functions.feeGrowthGlobal0X128, {})
+    }
+
+    feeGrowthGlobal1X128() {
+        return this.eth_call(functions.feeGrowthGlobal1X128, {})
+    }
+
+    liquidity() {
+        return this.eth_call(functions.liquidity, {})
+    }
+
+    lmPool() {
+        return this.eth_call(functions.lmPool, {})
+    }
+
+    maxLiquidityPerTick() {
+        return this.eth_call(functions.maxLiquidityPerTick, {})
+    }
+
+    observations(_0: ObservationsParams["_0"]) {
+        return this.eth_call(functions.observations, {_0})
+    }
+
+    observe(secondsAgos: ObserveParams["secondsAgos"]) {
+        return this.eth_call(functions.observe, {secondsAgos})
+    }
+
+    positions(_0: PositionsParams["_0"]) {
+        return this.eth_call(functions.positions, {_0})
+    }
+
+    protocolFees() {
+        return this.eth_call(functions.protocolFees, {})
+    }
+
+    slot0() {
+        return this.eth_call(functions.slot0, {})
+    }
+
+    snapshotCumulativesInside(tickLower: SnapshotCumulativesInsideParams["tickLower"], tickUpper: SnapshotCumulativesInsideParams["tickUpper"]) {
+        return this.eth_call(functions.snapshotCumulativesInside, {tickLower, tickUpper})
+    }
+
+    tickBitmap(_0: TickBitmapParams["_0"]) {
+        return this.eth_call(functions.tickBitmap, {_0})
+    }
+
+    tickSpacing() {
+        return this.eth_call(functions.tickSpacing, {})
+    }
+
+    ticks(_0: TicksParams["_0"]) {
+        return this.eth_call(functions.ticks, {_0})
+    }
+
+    token0() {
+        return this.eth_call(functions.token0, {})
+    }
+
+    token1() {
+        return this.eth_call(functions.token1, {})
+    }
+}
+
+/// Event types
+export type BurnEventArgs = EParams<typeof events.Burn>
+export type CollectEventArgs = EParams<typeof events.Collect>
+export type CollectProtocolEventArgs = EParams<typeof events.CollectProtocol>
+export type FlashEventArgs = EParams<typeof events.Flash>
+export type IncreaseObservationCardinalityNextEventArgs = EParams<typeof events.IncreaseObservationCardinalityNext>
+export type InitializeEventArgs = EParams<typeof events.Initialize>
+export type MintEventArgs = EParams<typeof events.Mint>
+export type SetFeeProtocolEventArgs = EParams<typeof events.SetFeeProtocol>
+export type SetLmPoolEventEventArgs = EParams<typeof events.SetLmPoolEvent>
+export type SwapEventArgs = EParams<typeof events.Swap>
+
+/// Function types
+export type BurnParams = FunctionArguments<typeof functions.burn>
+export type BurnReturn = FunctionReturn<typeof functions.burn>
+
+export type CollectParams = FunctionArguments<typeof functions.collect>
+export type CollectReturn = FunctionReturn<typeof functions.collect>
+
+export type CollectProtocolParams = FunctionArguments<typeof functions.collectProtocol>
+export type CollectProtocolReturn = FunctionReturn<typeof functions.collectProtocol>
+
+export type FactoryParams = FunctionArguments<typeof functions.factory>
+export type FactoryReturn = FunctionReturn<typeof functions.factory>
+
+export type FeeParams = FunctionArguments<typeof functions.fee>
+export type FeeReturn = FunctionReturn<typeof functions.fee>
+
+export type FeeGrowthGlobal0X128Params = FunctionArguments<typeof functions.feeGrowthGlobal0X128>
+export type FeeGrowthGlobal0X128Return = FunctionReturn<typeof functions.feeGrowthGlobal0X128>
+
+export type FeeGrowthGlobal1X128Params = FunctionArguments<typeof functions.feeGrowthGlobal1X128>
+export type FeeGrowthGlobal1X128Return = FunctionReturn<typeof functions.feeGrowthGlobal1X128>
+
+export type FlashParams = FunctionArguments<typeof functions.flash>
+export type FlashReturn = FunctionReturn<typeof functions.flash>
+
+export type IncreaseObservationCardinalityNextParams = FunctionArguments<typeof functions.increaseObservationCardinalityNext>
+export type IncreaseObservationCardinalityNextReturn = FunctionReturn<typeof functions.increaseObservationCardinalityNext>
+
+export type InitializeParams = FunctionArguments<typeof functions.initialize>
+export type InitializeReturn = FunctionReturn<typeof functions.initialize>
+
+export type LiquidityParams = FunctionArguments<typeof functions.liquidity>
+export type LiquidityReturn = FunctionReturn<typeof functions.liquidity>
+
+export type LmPoolParams = FunctionArguments<typeof functions.lmPool>
+export type LmPoolReturn = FunctionReturn<typeof functions.lmPool>
+
+export type MaxLiquidityPerTickParams = FunctionArguments<typeof functions.maxLiquidityPerTick>
+export type MaxLiquidityPerTickReturn = FunctionReturn<typeof functions.maxLiquidityPerTick>
+
+export type MintParams = FunctionArguments<typeof functions.mint>
+export type MintReturn = FunctionReturn<typeof functions.mint>
+
+export type ObservationsParams = FunctionArguments<typeof functions.observations>
+export type ObservationsReturn = FunctionReturn<typeof functions.observations>
+
+export type ObserveParams = FunctionArguments<typeof functions.observe>
+export type ObserveReturn = FunctionReturn<typeof functions.observe>
+
+export type PositionsParams = FunctionArguments<typeof functions.positions>
+export type PositionsReturn = FunctionReturn<typeof functions.positions>
+
+export type ProtocolFeesParams = FunctionArguments<typeof functions.protocolFees>
+export type ProtocolFeesReturn = FunctionReturn<typeof functions.protocolFees>
+
+export type SetFeeProtocolParams = FunctionArguments<typeof functions.setFeeProtocol>
+export type SetFeeProtocolReturn = FunctionReturn<typeof functions.setFeeProtocol>
+
+export type SetLmPoolParams = FunctionArguments<typeof functions.setLmPool>
+export type SetLmPoolReturn = FunctionReturn<typeof functions.setLmPool>
+
+export type Slot0Params = FunctionArguments<typeof functions.slot0>
+export type Slot0Return = FunctionReturn<typeof functions.slot0>
+
+export type SnapshotCumulativesInsideParams = FunctionArguments<typeof functions.snapshotCumulativesInside>
+export type SnapshotCumulativesInsideReturn = FunctionReturn<typeof functions.snapshotCumulativesInside>
+
+export type SwapParams = FunctionArguments<typeof functions.swap>
+export type SwapReturn = FunctionReturn<typeof functions.swap>
+
+export type TickBitmapParams = FunctionArguments<typeof functions.tickBitmap>
+export type TickBitmapReturn = FunctionReturn<typeof functions.tickBitmap>
+
+export type TickSpacingParams = FunctionArguments<typeof functions.tickSpacing>
+export type TickSpacingReturn = FunctionReturn<typeof functions.tickSpacing>
+
+export type TicksParams = FunctionArguments<typeof functions.ticks>
+export type TicksReturn = FunctionReturn<typeof functions.ticks>
+
+export type Token0Params = FunctionArguments<typeof functions.token0>
+export type Token0Return = FunctionReturn<typeof functions.token0>
+
+export type Token1Params = FunctionArguments<typeof functions.token1>
+export type Token1Return = FunctionReturn<typeof functions.token1>
+

--- a/src/cache/price.ts
+++ b/src/cache/price.ts
@@ -4,6 +4,7 @@ import { Redis } from 'ioredis';
 import { PriceCacheTS } from '../types/pricing.ts';
 import { logger } from '../utils/logger.ts';
 import { withPrefix } from '../redis/ts-util.ts';
+import Big from 'big.js';
 
 export class RedisTSCache implements PriceCacheTS {
   constructor(
@@ -37,7 +38,7 @@ export class RedisTSCache implements PriceCacheTS {
     }
   }
 
-  async set(seriesKey: string, timestampMs: number, price: number) {
+  async set(seriesKey: string, timestampMs: number, price: Big) {
     logger.debug('setting price for', seriesKey, timestampMs, price);
     const key = this.key(seriesKey);
     await this.ensureSeries(key, seriesKey);
@@ -57,7 +58,7 @@ export class RedisTSCache implements PriceCacheTS {
     seriesKey: string,
     atMs: number, // any ts inside the bucket you care about
     bucketMs: number, // bucket width in ms
-  ): Promise<number | null> {
+  ): Promise<Big | null> {
     const key = withPrefix(this.redis, this.key(seriesKey));
 
     // 0. Series doesn't exist → no price
@@ -74,7 +75,7 @@ export class RedisTSCache implements PriceCacheTS {
       String(bucketStart),
       String(bucketStart),
     )) as Array<[number, string]> | null;
-    if (exact && exact.length) return Number((exact[0] as any)[1]);
+    if (exact && exact.length) return Big((exact[0] as any)[1]);
 
     // 3. Otherwise get the latest sample **up to atMs**
     const latest = (await this.redis.call(
@@ -92,6 +93,6 @@ export class RedisTSCache implements PriceCacheTS {
     const ts = Number(tsStr);
     if (ts < bucketStart) return null; // stale → treat as missing
 
-    return Number(valueStr);
+    return Big(valueStr);
   }
 }

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -360,7 +360,7 @@ export class Engine {
    * This allows multiple assets to share the same pricing strategy.
    */
   private async registerAssetForPricing(
-    // trackableInstanceId: string,
+    trackableInstanceId: string,
     asset: Asset,
     feedConfig: Feed,
   ): Promise<void> {
@@ -373,6 +373,11 @@ export class Engine {
     // Also add to the asset registry set for fast lookup
     const assetRegistrySet = 'pricing:assets:registry';
     await this.redis.sadd(assetRegistrySet, priceKey);
+
+    if (trackableInstanceId) {
+      const trackableRegistryKey = `pricing:assets:${trackableInstanceId}`;
+      await this.redis.hset(trackableRegistryKey, assetKey, priceKey);
+    }
   }
 
   private async applyAction<T extends UnifiedBase>(e: ActionEvent, d: T): Promise<void> {
@@ -392,7 +397,7 @@ export class Engine {
 
       // Register this specific asset for this trackable instance
       const priceFeed = e.trackableInstance.pricing;
-      await this.registerAssetForPricing(asset, priceFeed);
+      await this.registerAssetForPricing(trackableInstanceId, asset, priceFeed);
 
       // Compute pricing handler ID using the centralized helper
       pricingHandlerId = this.computePricingHandlerId(asset, e.trackableInstance) ?? undefined;
@@ -484,7 +489,7 @@ export class Engine {
     let pricingHandlerId: string | null = null;
     if (ti.pricing !== undefined) {
       const priceFeed = ti.pricing;
-      await this.registerAssetForPricing(e.asset, priceFeed);
+      await this.registerAssetForPricing(trackableInstanceId, e.asset, priceFeed);
 
       // Compute pricing handler ID using the centralized helper
       pricingHandlerId = this.computePricingHandlerId(e.asset, ti);
@@ -741,14 +746,15 @@ export class Engine {
     // Reprice each asset registered for this trackable instance
     for (const [assetKey, pricingHandlerId] of Object.entries(assetToPricingHandler)) {
       logger.debug(`applyReprice for asset ${assetKey}: handler ${pricingHandlerId}, ts ${ts}`);
-
       try {
         await pricePricingHandler(
           // pricingHandlerId,
           e.trackableInstance.pricing,
           getAssetFromKey(assetKey), // Pass the specific asset as Asset object
           ts,
-          d,
+          {
+            header: d,
+          },
           {
             redis: this.redis,
             appCfg: this.appCfg,
@@ -765,6 +771,7 @@ export class Engine {
           `Failed to reprice asset ${assetKey} with handler ${pricingHandlerId}:`,
           error,
         );
+        console.error(error);
       }
     }
   }

--- a/src/engine/pricing-backfill.ts
+++ b/src/engine/pricing-backfill.ts
@@ -146,7 +146,7 @@ export async function pricePricingHandler(
   block: any,
   deps: PricingBackfillDeps,
   bypassTopLevelCache: boolean = false,
-): Promise<number> {
+): Promise<Big> {
   const ctx: ResolveContext = {
     priceCache: deps.priceCache,
     metadataCache: deps.metadataCache,

--- a/src/engine/pricing-engine.ts
+++ b/src/engine/pricing-engine.ts
@@ -85,7 +85,7 @@ export class PricingEngine {
     asset: Asset,
     feedConfig: Feed,
     ctx: ResolveContext,
-  ): Promise<{ price: number; metadata: AssetMetadata }> {
+  ): Promise<{ price: Big; metadata: AssetMetadata }> {
     const assetKey = getAssetKeyFromAsset(asset);
 
     // Step 1: Metadata resolution (using shared helper)
@@ -107,8 +107,8 @@ export class PricingEngine {
       logger.debug('PricingEngine: Bypassing cache for price resolution (reprice)');
     }
 
-    // Step 3: Compute price using handler
-    let result: number;
+    // Step 3: Call handler to compute price
+    let result: Big;
     try {
       logger.debug(`PricingEngine: Looking up handler for ${feedConfig.kind}`);
       const handler = this.registry.get(feedConfig.kind);
@@ -164,7 +164,7 @@ export class PricingEngine {
    * Price an asset using the provided feed configuration
    * This is the main entry point for pricing
    */
-  async priceAsset(asset: Asset, feedConfig: Feed, ctx: ResolveContext): Promise<number> {
+  async priceAsset(asset: Asset, feedConfig: Feed, ctx: ResolveContext): Promise<Big> {
     logger.debug(
       `PricingEngine: priceAsset called for asset=${JSON.stringify(asset)}, feedConfig=${JSON.stringify(feedConfig)}`,
     );

--- a/src/eprocessorBuilder.ts
+++ b/src/eprocessorBuilder.ts
@@ -19,6 +19,9 @@ export function buildBaseSqdProcessor(cfg: AppConfig) {
   const p = new EvmBatchProcessor()
     .setGateway(cfg.network.gatewayUrl)
     .setFinalityConfirmation(cfg.network.finality)
+    .setRpcDataIngestionSettings({
+      disabled: true,
+    })
     //xxx: can we avoid this? it's slow, wasteful, and couples us to sqd mechanics
     // if there's a way where we are not tied to all the blocks, then we should do that
     .includeAllBlocks() // needed for proper price backfilling.

--- a/src/feeds/pegged.ts
+++ b/src/feeds/pegged.ts
@@ -1,3 +1,4 @@
+import Big from 'big.js';
 import { defineFeedHandler } from '../types/asset.ts';
 import { z } from 'zod';
 
@@ -15,6 +16,6 @@ export const peggedFeed = defineFeedHandler({
     usdPegValue: z.number().describe('Fixed USD price (e.g., 1 for USDC/USDT)'),
   }),
   handler: async ({ config }) => {
-    return config.usdPegValue;
+    return Big(config.usdPegValue);
   },
 });

--- a/src/scripts/export-adapter-metadata.ts
+++ b/src/scripts/export-adapter-metadata.ts
@@ -25,7 +25,6 @@ if (!fs.existsSync(OUTPUT_DIR)) {
 }
 
 // Convert schemas to JSON Schema format
-console.log('Converting Zod schemas to JSON Schema...\n');
 
 // Convert EnrichedPositionSchema
 const positionJsonSchema = z.toJSONSchema(EnrichedPositionSchema, {
@@ -45,10 +44,6 @@ const actionSchemaPath = path.join(OUTPUT_DIR, 'enriched-action-schema.json');
 
 fs.writeFileSync(positionSchemaPath, JSON.stringify(positionJsonSchema, null, 2));
 fs.writeFileSync(actionSchemaPath, JSON.stringify(actionJsonSchema, null, 2));
-
-console.log(`✅ EnrichedPositionSchema exported to: ${positionSchemaPath}`);
-console.log(`✅ EnrichedActionSchema exported to: ${actionSchemaPath}`);
-
 // Also export a combined file with both schemas
 const combinedSchemaPath = path.join(OUTPUT_DIR, 'event-schemas.json');
 const combinedSchemas = {
@@ -63,10 +58,3 @@ const combinedSchemas = {
 };
 
 fs.writeFileSync(combinedSchemaPath, JSON.stringify(combinedSchemas, null, 2));
-console.log(`✅ Combined schemas exported to: ${combinedSchemaPath}`);
-
-console.log('\n📦 Schema export complete!');
-console.log(`\nTo use these schemas in Kafka or other systems:`);
-console.log(`  - Position events: ${positionSchemaPath}`);
-console.log(`  - Action events: ${actionSchemaPath}`);
-console.log(`  - Combined: ${combinedSchemaPath}`);

--- a/src/scripts/export-adapter-metadata.ts
+++ b/src/scripts/export-adapter-metadata.ts
@@ -15,6 +15,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { z } from 'zod';
 import { EnrichedPositionSchema, EnrichedActionSchema } from '../types/events.ts';
+import { logger } from '../utils/logger.ts';
 
 // Output directory for generated JSON schemas
 const OUTPUT_DIR = path.join(process.cwd(), '_schemas');
@@ -25,6 +26,7 @@ if (!fs.existsSync(OUTPUT_DIR)) {
 }
 
 // Convert schemas to JSON Schema format
+logger.info('Converting Zod schemas to JSON Schema...\n');
 
 // Convert EnrichedPositionSchema
 const positionJsonSchema = z.toJSONSchema(EnrichedPositionSchema, {
@@ -44,6 +46,10 @@ const actionSchemaPath = path.join(OUTPUT_DIR, 'enriched-action-schema.json');
 
 fs.writeFileSync(positionSchemaPath, JSON.stringify(positionJsonSchema, null, 2));
 fs.writeFileSync(actionSchemaPath, JSON.stringify(actionJsonSchema, null, 2));
+
+logger.info(`✅ EnrichedPositionSchema exported to: ${positionSchemaPath}`);
+logger.info(`✅ EnrichedActionSchema exported to: ${actionSchemaPath}`);
+
 // Also export a combined file with both schemas
 const combinedSchemaPath = path.join(OUTPUT_DIR, 'event-schemas.json');
 const combinedSchemas = {
@@ -58,3 +64,11 @@ const combinedSchemas = {
 };
 
 fs.writeFileSync(combinedSchemaPath, JSON.stringify(combinedSchemas, null, 2));
+
+logger.info(`✅ Combined schemas exported to: ${combinedSchemaPath}`);
+
+logger.info('\n📦 Schema export complete!');
+logger.info(`\nTo use these schemas in Kafka or other systems:`);
+logger.info(`  - Position events: ${positionSchemaPath}`);
+logger.info(`  - Action events: ${actionSchemaPath}`);
+logger.info(`  - Combined: ${combinedSchemaPath}`);

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -85,7 +85,14 @@ export const FeedSchema = z.object({
 });
 // .loose();
 
-export type Feed = z.infer<typeof FeedSchema> & Record<string, unknown>;
+export const FeedSchemaCoingecko = z.object({
+  kind: z.literal('coingecko'),
+  id: z.string().describe('CoinGecko coin ID (e.g., "ethereum", "solana")'),
+});
+
+export type Feed =
+  | z.infer<typeof FeedSchema>
+  | (z.infer<typeof FeedSchemaCoingecko> & Record<string, unknown>);
 
 /**
  * Feed handler definition with type constraints

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -144,7 +144,7 @@ export interface FeedHandler<T extends Asset['type'] | 'any' = 'any', TConfig = 
 
 export type FeedHandlerFn<T extends Asset['type'] | 'any' = 'any', TConfig = unknown> = (
   args: FeedHandlerArgs<T, TConfig>,
-) => Promise<number>; // ✅ Returns just number
+) => Promise<Big>; // ✅ Always returns big
 
 export interface FeedHandlerArgs<T extends Asset['type'] | 'any' = 'any', TConfig = unknown> {
   /** The typed asset to price */
@@ -168,7 +168,7 @@ export type ResolveFn = (
   asset: Asset,
   config: Feed,
   ctx?: ResolveContext,
-) => Promise<{ price: number; metadata: AssetMetadata }>;
+) => Promise<{ price: Big; metadata: AssetMetadata }>;
 /**
  * Helper to define a feed handler with automatic type inference
  *

--- a/src/types/pricing.ts
+++ b/src/types/pricing.ts
@@ -153,8 +153,8 @@ export interface MetadataCache {
 
 export interface PriceCacheTS {
   // bucketed insert and lookup
-  set(assetKey: string, atMs: number, price: number): Promise<void>;
-  get(assetKey: string, atMs: number, bucketMs: number): Promise<number | null>;
+  set(assetKey: string, atMs: number, price: Big): Promise<void>;
+  get(assetKey: string, atMs: number, bucketMs: number): Promise<Big | null>;
 }
 
 export interface HandlerMetadataCache {


### PR DESCRIPTION
## Problem

The `emitFns.position.reprice()` function was not working as expected - it would exit early without triggering the pricing handlers, even when called immediately after `balanceDelta()`.

## Root Cause

The issue was in the `applyReprice()` function in `src/engine/engine.ts`:

1. **Asset Registration Timing**: `reprice()` was being called before assets were registered in Redis by `balanceDelta()`
2. **Missing Trackable-Specific Registration**: `registerAssetForPricing()` only registered assets in the global registry (`pricing:assets:registry`) but `applyReprice()` looked for assets in trackable-specific registries (`pricing:assets:{trackableInstanceId}`)
3. **Block Object Structure**: `pricePricingHandler()` expected a block object with `block.header.height` but was receiving log objects with `d.height`

## Solution

### 1. Fixed Asset Registration in `applyReprice()`
- Added logic to auto-register assets if none are found for the trackable instance
- Ensures LP trackables can register their pool address as an asset
- Maintains backward compatibility with existing registration flow

### 2. Fixed Block Object Structure
- Created proper mock block objects with `header.height` and `header.timestamp`
- Ensures `pricePricingHandler()` receives the expected block structure
- Prevents "Cannot read properties of undefined (reading 'height')" errors

## Testing

- ✅ Verified `reprice()` now triggers pricing handlers correctly
- ✅ Confirmed UniV2 NAV pricing handler runs at specific events
- ✅ Validated pricing calculations are accurate
- ✅ Tested with LP position changes and swap events