### PR TITLE
refactor: group trackable instances by type and chain for easier poin…

### DIFF
--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -164,6 +164,7 @@ function validateInstance(
   instanceIdx: number,
 ): any {
   const validated: Record<string, any> = {
+    trackableName: trackableId, // Include trackable name for ID generation and filtering
     quantityType: trackableDef.quantityType,
   };
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -337,16 +337,18 @@ export class Engine {
   }
 
   /**
-   * Generate a stable ID for a trackable instance based on its configuration.
-   * This ID uniquely identifies a pricing strategy scope.
+   * Generate a stable ID for a trackable instance based on chainId and trackable name.
+   * This groups all instances of the same trackable type (e.g., all "bid" configs) under one ID.
+   * Different chains get different IDs. Different trackable types get different IDs.
+   * But all config variants within the same trackable type on the same chain share the same ID.
    */
   private generateTrackableInstanceId(ti: InstanceFrom<TrackableDef>): string {
-    // Hash the trackable instance's identifying properties
+    const { chainId } = getRuntime();
+    // Hash chainId + trackableName only (not params/assetSelectors)
+    // This allows filtering by event type (bid, claim, swap) and by chain
     const key = {
-      params: ti.params,
-      quantityType: ti.quantityType,
-      // Include assetSelectors if present (for swaps)
-      ...('assetSelectors' in ti && ti.assetSelectors ? { assetSelectors: ti.assetSelectors } : {}),
+      chainId,
+      trackableName: ti.trackableName, // e.g., "bid", "claim", "swap"
     };
     return md5HashCanonical(key, 16);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import { loadAllAdapters } from './adapters/loader.ts';
 
 import { BaseProcessor } from './eprocessorBuilder.ts';
 import { md5HashCanonical } from './utils/stable-hash.ts';
-import { setRuntime } from './runtime/context.ts';
+import { getRuntime, setRuntime } from './runtime/context.ts';
 import { ABSINTHE_VERSION } from './constants.ts';
 import os from 'os';
 import { clearStateDir, clearRedisNamespace, deriveStateDirFromHash } from './utils/state-reset.ts';
@@ -167,11 +167,11 @@ async function main() {
     for (const [trackableId, instances] of Object.entries(
       validatedInstances as Record<string, any[]>,
     )) {
+      const { chainId } = getRuntime();
       instances.forEach((inst, idx) => {
         const key = {
-          params: inst.params,
-          quantityType: inst.quantityType,
-          ...(inst.assetSelectors ? { assetSelectors: inst.assetSelectors } : {}),
+          chainId,
+          trackableName: trackableId,
         };
         const trackable_instance_id = md5HashCanonical(key, 16);
 

--- a/src/types/manifest.ts
+++ b/src/types/manifest.ts
@@ -218,6 +218,7 @@ type PricingFrom<T extends TrackableDef> = {
 };
 
 export type InstanceFrom<T extends TrackableDef> = {
+  trackableName: string;
   params: ParamsFrom<T>;
   quantityType: T['quantityType'];
 } & (T extends { assetSelectors: Record<string, AssetSelectorDef<any>> }


### PR DESCRIPTION
…t source setup

Simplify trackable_instance_id to hash(chainId + trackableName) instead of including params/assetSelectors. This allows all instances of the same trackable type (e.g., all bid configs) on the same chain to share one ID, enabling easier point source configuration by event type and chain.