### PR TITLE
feat: add adapter catalog generation with auto-publish workflow

### DIFF
--- a/.github/workflows/deploy-adapter-catalog.yml
+++ b/.github/workflows/deploy-adapter-catalog.yml
@@ -1,0 +1,77 @@
+name: Publish Adapter Catalog to npm
+
+on:
+    push:
+        branches:
+            - develop-next
+    workflow_dispatch:
+
+jobs:
+    check-and-publish:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            packages: write
+            id-token: write
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - uses: pnpm/action-setup@v4
+              with:
+                  version: 10
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+                  registry-url: "https://registry.npmjs.org"
+                  cache: "pnpm"
+
+            - run: pnpm install --frozen-lockfile
+
+            - name: Check for adapter changes
+              id: changes
+              run: |
+                  if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+                    echo "HAS_CHANGES=true" >> $GITHUB_OUTPUT
+                  else
+                    if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E '^adapters/[^/]+/metadata\.ts$'; then
+                      echo "HAS_CHANGES=true" >> $GITHUB_OUTPUT
+                    else
+                      echo "HAS_CHANGES=false" >> $GITHUB_OUTPUT
+                    fi
+                  fi
+
+            - name: Skip if no changes
+              if: steps.changes.outputs.HAS_CHANGES != 'true'
+              run: exit 0
+
+            - name: Bump minor version
+              id: bump
+              run: |
+                  CURRENT=$(node -p "require('./package.json').version")
+                  IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+                  NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
+                  echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+                  npm version $NEW_VERSION --no-git-tag-version
+
+            - run: pnpm build
+            - run: pnpm generate-catalog
+
+            - name: Commit and tag
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add package.json _generated/adapter-catalog.json
+                  git commit -m "chore: bump catalog version to ${{ steps.bump.outputs.NEW_VERSION }} [skip ci]" || true
+                  git push origin ${{ github.ref_name }} || true
+                  git tag -a "v${{ steps.bump.outputs.NEW_VERSION }}" -m "Catalog v${{ steps.bump.outputs.NEW_VERSION }}"
+                  git push origin "v${{ steps.bump.outputs.NEW_VERSION }}"
+
+            - name: Publish to npm
+              run: pnpm publish --access public --no-git-checks
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ out*.txt
 _sqdstate/
 _runs/
 _schemas/
+_generated/

--- a/_generated/adapter-catalog.json
+++ b/_generated/adapter-catalog.json
@@ -1,0 +1,281 @@
+{
+  "generatedAt": "2025-12-11T16:22:28.352Z",
+  "adapters": {
+    "protocol-name": {
+      "displayName": "Protocol Name",
+      "description": "Brief description of what this protocol does and what this adapter tracks.",
+      "category": "trading",
+      "tags": [
+        "protocol",
+        "category",
+        "keywords"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "",
+      "status": "beta",
+      "createdAt": "2025-10-07",
+      "trackables": []
+    },
+    "concrete": {
+      "displayName": "Concrete vaults",
+      "description": "Concrete vaults",
+      "category": "lending",
+      "tags": [
+        "concrete",
+        "vaults",
+        "evm"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "https://raw.githubusercontent.com/0xa3k5/web3icons/refs/heads/main/raw-svgs/exchanges/branded/uniswap.svg",
+      "status": "beta",
+      "compatibleWith": "uniswap-v2",
+      "createdAt": "2025-11-26",
+      "trackables": [
+        {
+          "name": "Vault Deposits",
+          "description": "Track vault deposits on Concrete."
+        },
+        {
+          "name": "Vaults",
+          "description": "Track Concrete vaults positions."
+        }
+      ]
+    },
+    "erc20-holdings": {
+      "displayName": "ERC20 Holdings",
+      "description": "Tracks the holdings of an ERC20 token.",
+      "category": "tokens",
+      "tags": [
+        "erc20",
+        "holdings"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "",
+      "status": "beta",
+      "createdAt": "2025-10-07",
+      "trackables": [
+        {
+          "name": "Token Balance",
+          "description": "Track wallet balances for an ERC20 token contract. Monitors transfers to and from wallets, providing real-time balance updates."
+        }
+      ]
+    },
+    "gbm-auctions-legacy": {
+      "displayName": "GBM Auctions Legacy",
+      "description": "GBM Auctions Legacy is a decentralized auction protocol that allows users to bid on ERC20 tokens.",
+      "category": "auctions",
+      "tags": [
+        "gbm",
+        "auctions",
+        "legacy",
+        "evm"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "https://raw.githubusercontent.com/0xa3k5/web3icons/refs/heads/main/raw-svgs/exchanges/branded/uniswap.svg",
+      "status": "beta",
+      "compatibleWith": "uniswap-v2",
+      "createdAt": "2025-10-11",
+      "trackables": [
+        {
+          "name": "Bid",
+          "description": "Track bids on GBM Auctions Legacy."
+        },
+        {
+          "name": "Claim",
+          "description": "Track claims on GBM Auctions Legacy."
+        }
+      ]
+    },
+    "gbm-auctions-new": {
+      "displayName": "GBM Auctions New",
+      "description": "GBM Auctions New is a decentralized auction protocol that allows users to bid on ERC20 tokens.",
+      "category": "auctions",
+      "tags": [
+        "gbm",
+        "auctions",
+        "new",
+        "evm"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "https://raw.githubusercontent.com/0xa3k5/web3icons/refs/heads/main/raw-svgs/exchanges/branded/uniswap.svg",
+      "status": "beta",
+      "compatibleWith": "uniswap-v2",
+      "createdAt": "2025-10-11",
+      "trackables": [
+        {
+          "name": "Bid",
+          "description": "Track bids on GBM Auctions New."
+        },
+        {
+          "name": "Claim",
+          "description": "Track claims on GBM Auctions New."
+        }
+      ]
+    },
+    "morpho-markets": {
+      "displayName": "Morpho markets",
+      "description": "Morpho markets",
+      "category": "lending",
+      "tags": [
+        "morpho",
+        "markets",
+        "evm"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "https://raw.githubusercontent.com/0xa3k5/web3icons/refs/heads/main/raw-svgs/exchanges/branded/uniswap.svg",
+      "status": "beta",
+      "compatibleWith": "uniswap-v2",
+      "createdAt": "2025-10-11",
+      "trackables": [
+        {
+          "name": "Morpho Blue",
+          "description": "Track Morpho Blue positions on Morpho markets."
+        }
+      ]
+    },
+    "morpho-vaultsv1": {
+      "displayName": "Morpho V1 vaults",
+      "description": "Morpho v1 vaults",
+      "category": "lending",
+      "tags": [
+        "gbm",
+        "auctions",
+        "legacy",
+        "evm"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "https://raw.githubusercontent.com/0xa3k5/web3icons/refs/heads/main/raw-svgs/exchanges/branded/uniswap.svg",
+      "status": "beta",
+      "compatibleWith": "uniswap-v2",
+      "createdAt": "2025-10-11",
+      "trackables": [
+        {
+          "name": "Create Meta Morpho Factory",
+          "description": "Track create meta morpho factory on Morpho V1 vaults."
+        },
+        {
+          "name": "Vaults",
+          "description": "Track Morpho V1 vaults positions."
+        }
+      ]
+    },
+    "morpho-vaultsv2": {
+      "displayName": "Morpho V1 vaults",
+      "description": "Morpho v1 vaults",
+      "category": "lending",
+      "tags": [
+        "gbm",
+        "auctions",
+        "legacy",
+        "evm"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "https://raw.githubusercontent.com/0xa3k5/web3icons/refs/heads/main/raw-svgs/exchanges/branded/uniswap.svg",
+      "status": "beta",
+      "compatibleWith": "uniswap-v2",
+      "createdAt": "2025-10-11",
+      "trackables": [
+        {
+          "name": "Create Meta Morpho Factory",
+          "description": "Track create meta morpho factory on Morpho V2 vaults."
+        },
+        {
+          "name": "Vaults",
+          "description": "Track Morpho V2 vaults positions."
+        }
+      ]
+    },
+    "onlymeid": {
+      "displayName": "OnlyMeID",
+      "description": "Track user verification actions on the OnlyMeID protocol.",
+      "category": "identity",
+      "tags": [
+        "identity",
+        "verification",
+        "onlymeid"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "",
+      "status": "beta",
+      "createdAt": "2025-10-16",
+      "trackables": []
+    },
+    "uniswap-v2": {
+      "displayName": "Uniswap V2",
+      "description": "Uniswap V2 is a decentralized exchange protocol that allows users to swap ERC20 tokens.",
+      "category": "trading",
+      "tags": [
+        "uniswap",
+        "v2",
+        "dex",
+        "amm",
+        "evm"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "https://raw.githubusercontent.com/0xa3k5/web3icons/refs/heads/main/raw-svgs/exchanges/branded/uniswap.svg",
+      "status": "beta",
+      "compatibleWith": "uniswap-v2",
+      "createdAt": "2025-10-02",
+      "trackables": [
+        {
+          "name": "Swap",
+          "description": "Track swaps on Uniswap V2."
+        },
+        {
+          "name": "Liquidity Position",
+          "description": "Track liquidity positions on Uniswap V2."
+        }
+      ]
+    },
+    "uniswap-v3": {
+      "displayName": "Uniswap V3",
+      "description": "Uniswap V3 is a decentralized exchange protocol with concentrated liquidity and multiple fee tiers. Track swaps and liquidity positions.",
+      "category": "trading",
+      "tags": [
+        "uniswap",
+        "v3",
+        "dex",
+        "amm",
+        "evm",
+        "concentrated-liquidity"
+      ],
+      "author": "Absinthe",
+      "authorUrl": "https://absinthe.network",
+      "authorIcon": "https://app.absinthe.network/images/absinthefavicon.png",
+      "adapterIcon": "https://raw.githubusercontent.com/0xa3k5/web3icons/refs/heads/main/raw-svgs/exchanges/branded/uniswap.svg",
+      "status": "beta",
+      "compatibleWith": "uniswap-v3",
+      "createdAt": "2025-10-11",
+      "trackables": [
+        {
+          "name": "Swap",
+          "description": "Track token swaps on Uniswap V3 pools. Each swap event captures the trade between token0 and token1, including the amount swapped and price impact."
+        },
+        {
+          "name": "Liquidity Position",
+          "description": "Track NFT-based concentrated liquidity positions. Captures mints, burns, increases, decreases, and transfers of liquidity positions with specific price ranges."
+        }
+      ]
+    }
+  }
+}

--- a/adapters/concrete/metadata.ts
+++ b/adapters/concrete/metadata.ts
@@ -19,4 +19,14 @@ export const metadata = {
   status: 'beta',
   compatibleWith: 'uniswap-v2',
   createdAt: '2025-11-26',
+  trackables: {
+    vaultDeposits: {
+      displayName: 'Vault Deposits',
+      description: 'Track vault deposits on Concrete.',
+    },
+    vaults: {
+      displayName: 'Vaults',
+      description: 'Track Concrete vaults positions.',
+    },
+  },
 } as const satisfies AdapterMetadata;

--- a/adapters/erc20-holdings/metadata.ts
+++ b/adapters/erc20-holdings/metadata.ts
@@ -18,4 +18,12 @@ export const metadata = {
   adapterIcon: '',
   status: 'beta', // 'stable', 'beta', or 'deprecated'
   createdAt: '2025-10-07',
+  // Human-readable descriptions for each trackable (must match trackable IDs in manifest)
+  trackables: {
+    token: {
+      displayName: 'Token Balance',
+      description:
+        'Track wallet balances for an ERC20 token contract. Monitors transfers to and from wallets, providing real-time balance updates.',
+    },
+  },
 } as const satisfies AdapterMetadata;

--- a/adapters/gbm-auctions-legacy/metadata.ts
+++ b/adapters/gbm-auctions-legacy/metadata.ts
@@ -20,4 +20,14 @@ export const metadata = {
   status: 'beta',
   compatibleWith: 'uniswap-v2',
   createdAt: '2025-10-11',
+  trackables: {
+    bid: {
+      displayName: 'Bid',
+      description: 'Track bids on GBM Auctions Legacy.',
+    },
+    claim: {
+      displayName: 'Claim',
+      description: 'Track claims on GBM Auctions Legacy.',
+    },
+  },
 } as const satisfies AdapterMetadata;

--- a/adapters/gbm-auctions-new/metadata.ts
+++ b/adapters/gbm-auctions-new/metadata.ts
@@ -20,4 +20,14 @@ export const metadata = {
   status: 'beta',
   compatibleWith: 'uniswap-v2',
   createdAt: '2025-10-11',
+  trackables: {
+    bid: {
+      displayName: 'Bid',
+      description: 'Track bids on GBM Auctions New.',
+    },
+    claim: {
+      displayName: 'Claim',
+      description: 'Track claims on GBM Auctions New.',
+    },
+  },
 } as const satisfies AdapterMetadata;

--- a/adapters/morphomarkets/metadata.ts
+++ b/adapters/morphomarkets/metadata.ts
@@ -19,4 +19,10 @@ export const metadata = {
   status: 'beta',
   compatibleWith: 'uniswap-v2',
   createdAt: '2025-10-11',
+  trackables: {
+    morphoblue: {
+      displayName: 'Morpho Blue',
+      description: 'Track Morpho Blue positions on Morpho markets.',
+    },
+  },
 } as const satisfies AdapterMetadata;

--- a/adapters/morphov1vaults/metadata.ts
+++ b/adapters/morphov1vaults/metadata.ts
@@ -19,4 +19,14 @@ export const metadata = {
   status: 'beta',
   compatibleWith: 'uniswap-v2',
   createdAt: '2025-10-11',
+  trackables: {
+    createMetaMorphoFactory: {
+      displayName: 'Create Meta Morpho Factory',
+      description: 'Track create meta morpho factory on Morpho V1 vaults.',
+    },
+    vaults: {
+      displayName: 'Vaults',
+      description: 'Track Morpho V1 vaults positions.',
+    },
+  },
 } as const satisfies AdapterMetadata;

--- a/adapters/morphov2vaults/metadata.ts
+++ b/adapters/morphov2vaults/metadata.ts
@@ -19,4 +19,14 @@ export const metadata = {
   status: 'beta',
   compatibleWith: 'uniswap-v2',
   createdAt: '2025-10-11',
+  trackables: {
+    createMetaMorphoFactory: {
+      displayName: 'Create Meta Morpho Factory',
+      description: 'Track create meta morpho factory on Morpho V2 vaults.',
+    },
+    vaults: {
+      displayName: 'Vaults',
+      description: 'Track Morpho V2 vaults positions.',
+    },
+  },
 } as const satisfies AdapterMetadata;

--- a/adapters/uniswap-v2/metadata.ts
+++ b/adapters/uniswap-v2/metadata.ts
@@ -20,4 +20,14 @@ export const metadata = {
   status: 'beta',
   compatibleWith: 'uniswap-v2',
   createdAt: '2025-10-02',
+  trackables: {
+    swap: {
+      displayName: 'Swap',
+      description: 'Track swaps on Uniswap V2.',
+    },
+    lp: {
+      displayName: 'Liquidity Position',
+      description: 'Track liquidity positions on Uniswap V2.',
+    },
+  },
 } as const satisfies AdapterMetadata;

--- a/adapters/uniswap-v3/metadata.ts
+++ b/adapters/uniswap-v3/metadata.ts
@@ -20,4 +20,17 @@ export const metadata = {
   status: 'beta',
   compatibleWith: 'uniswap-v3',
   createdAt: '2025-10-11',
+  // Human-readable descriptions for each trackable (must match trackable IDs in manifest)
+  trackables: {
+    swap: {
+      displayName: 'Swap',
+      description:
+        'Track token swaps on Uniswap V3 pools. Each swap event captures the trade between token0 and token1, including the amount swapped and price impact.',
+    },
+    lp: {
+      displayName: 'Liquidity Position',
+      description:
+        'Track NFT-based concentrated liquidity positions. Captures mints, burns, increases, decreases, and transfers of liquidity positions with specific price ranges.',
+    },
+  },
 } as const satisfies AdapterMetadata;

--- a/package.json
+++ b/package.json
@@ -11,12 +11,16 @@
     "./types": {
       "types": "./dist/src/types/events.d.ts",
       "default": "./dist/src/types/events.js"
+    },
+    "./catalog": {
+      "default": "./_generated/adapter-catalog.json"
     }
   },
   "files": [
     "dist/src/schemas",
     "dist/src/types/events.js",
-    "dist/src/types/events.d.ts"
+    "dist/src/types/events.d.ts",
+    "_generated/adapter-catalog.json"
   ],
   "scripts": {
     "build": "tsc",
@@ -25,7 +29,7 @@
     "build:docker:no-cache": "docker build --no-cache --rm --build-arg GIT_COMMIT_SHA_LONG=$(git rev-parse HEAD) -f src/Dockerfile -t yada:latest .",
     "prepare": "pnpm --filter @absinthe/schemas build",
     "pretest": "pnpm build",
-    "prepublishOnly": "pnpm build",
+    "prepublishOnly": "pnpm build && pnpm generate-catalog",
     "test": "vitest run",
     "test:watch": "vitest",
     "prestart": "pnpm build",
@@ -38,7 +42,8 @@
     "migration:apply": "squid-typeorm-migration apply",
     "lint-staged": "lint-staged",
     "migration": "pnpm build && pnpm migration:clean && pnpm migration:generate && pnpm migration:apply",
-    "export-schemas": "pnpm build && node dist/src/scripts/export-adapter-metadata.js"
+    "export-schemas": "pnpm build && node dist/src/scripts/export-adapter-metadata.js",
+    "generate-catalog": "pnpm build && node dist/src/scripts/generate-adapter-catalog.js"
   },
   "packageManager": "pnpm@10.19.0+sha512.c9fc7236e92adf5c8af42fd5bf1612df99c2ceb62f27047032f4720b33f8eacdde311865e91c411f2774f618d82f320808ecb51718bfa82c060c4ba7c76a32b8",
   "dependencies": {

--- a/src/adapter-registry.ts
+++ b/src/adapter-registry.ts
@@ -13,6 +13,7 @@ const registry = new Map<string, AdapterDef<Manifest>>();
 /** Adapter definition combining manifest with build function */
 export type AdapterDef<M extends Manifest> = {
   manifest: M;
+  metadata: AdapterMetadata;
   feedHandlers?: CustomFeedHandlers;
   build: (opts: { config: ConfigFromManifest<M>; io: EngineIO }) => BuiltAdapter;
 };
@@ -22,7 +23,11 @@ export function defineAdapter<const M extends Manifest>(def: {
   metadata: AdapterMetadata;
   build: (opts: { config: ConfigFromManifest<M>; io: EngineIO }) => BuiltAdapter;
 }): AdapterDef<M> {
-  const adapterDef = def as AdapterDef<M>;
+  const adapterDef: AdapterDef<M> = {
+    manifest: def.manifest,
+    metadata: def.metadata,
+    build: def.build,
+  };
 
   // Register immediately as side effect
   registerAdapter(adapterDef);
@@ -102,4 +107,14 @@ export function getAdapterMeta(adapterId: string): { name: string; semver: strin
 // Get full manifest if needed elsewhere
 export function getManifest(adapterId: string): Manifest | null {
   return registry.get(adapterId)?.manifest ?? null;
+}
+
+// Get adapter metadata
+export function getAdapterMetadata(adapterId: string): AdapterMetadata | null {
+  return registry.get(adapterId)?.metadata ?? null;
+}
+
+// Get all registered adapters (for catalog generation)
+export function getAllAdapters(): Map<string, AdapterDef<Manifest>> {
+  return new Map(registry);
 }

--- a/src/scripts/generate-adapter-catalog.ts
+++ b/src/scripts/generate-adapter-catalog.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Generate Adapter Catalog
+ *
+ * This script loads all adapters and generates a simple metadata JSON file
+ * containing only human-readable information from adapter metadata.
+ *
+ * Usage:
+ *   pnpm run generate-catalog
+ *   or
+ *   node dist/src/scripts/generate-adapter-catalog.js
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { loadAllAdapters } from '../adapters/loader.ts';
+import { getAllAdapters } from '../adapter-registry.ts';
+import { logger } from '../utils/logger.ts';
+
+// Output directory for generated catalog
+const OUTPUT_DIR = path.join(process.cwd(), '_generated');
+
+// Simple trackable entry
+type TrackableEntry = {
+  name: string;
+  description: string;
+};
+
+// Simple adapter entry (only from metadata)
+type AdapterCatalogEntry = {
+  displayName: string;
+  description: string;
+  category?: string;
+  tags?: string[];
+  author: string;
+  authorUrl?: string;
+  authorIcon?: string;
+  adapterIcon?: string;
+  status?: string;
+  compatibleWith?: string;
+  createdAt: string;
+  trackables: TrackableEntry[];
+};
+
+// Catalog structure
+type AdapterCatalog = {
+  version: string;
+  generatedAt: string;
+  adapters: Record<string, AdapterCatalogEntry>;
+};
+
+async function main() {
+  logger.info('🔍 Loading all adapters...\n');
+
+  // Read package.json to get version
+  const packageJsonPath = path.join(process.cwd(), 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  const version = packageJson.version;
+
+  logger.info(`📦 Using version: ${version}\n`);
+
+  // Load all adapters (this registers them in the registry)
+  await loadAllAdapters();
+
+  // Get all registered adapters
+  const adapters = getAllAdapters();
+
+  logger.info(`📦 Found ${adapters.size} adapters\n`);
+
+  // Build the catalog
+  const catalog: AdapterCatalog = {
+    version,
+    generatedAt: new Date().toISOString(),
+    adapters: {},
+  };
+
+  for (const [adapterId, adapterDef] of adapters) {
+    logger.info(`  Processing: ${adapterId}`);
+
+    const metadata = adapterDef.metadata;
+
+    // Convert trackables from object to array
+    const trackables: TrackableEntry[] = [];
+    if (metadata.trackables) {
+      for (const [trackableId, trackableMeta] of Object.entries(metadata.trackables)) {
+        trackables.push({
+          name: trackableMeta.displayName,
+          description: trackableMeta.description,
+        });
+      }
+    }
+
+    catalog.adapters[adapterId] = {
+      displayName: metadata.displayName,
+      description: metadata.description,
+      category: metadata.category,
+      tags: metadata.tags,
+      author: metadata.author,
+      authorUrl: metadata.authorUrl,
+      authorIcon: metadata.authorIcon,
+      adapterIcon: metadata.adapterIcon,
+      status: metadata.status,
+      compatibleWith: metadata.compatibleWith,
+      createdAt: metadata.createdAt,
+      trackables,
+    };
+  }
+
+  // Ensure output directory exists
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+
+  // Write the catalog
+  const catalogPath = path.join(OUTPUT_DIR, 'adapter-catalog.json');
+  fs.writeFileSync(catalogPath, JSON.stringify(catalog, null, 2));
+
+  logger.info(`\n✅ Adapter catalog generated: ${catalogPath}`);
+  logger.info(`   Total adapters: ${Object.keys(catalog.adapters).length}`);
+}
+
+main().catch((err) => {
+  logger.error('Failed to generate adapter catalog:', err);
+  process.exit(1);
+});

--- a/src/types/manifest.ts
+++ b/src/types/manifest.ts
@@ -240,6 +240,14 @@ export const ManifestZ = z
   })
   .strict();
 
+// Trackable metadata - human-readable info about each trackable for UI display
+export const TrackableMetadataZ = z.object({
+  displayName: z.string().min(1).max(60),
+  description: z.string().min(1).max(500),
+});
+
+export type TrackableMetadata = z.infer<typeof TrackableMetadataZ>;
+
 // Optional validation schema for metadata
 export const AdapterMetadataZ = z
   .object({
@@ -259,6 +267,8 @@ export const AdapterMetadataZ = z
     adapterIcon: z.httpUrl().optional(),
     status: z.enum(['stable', 'beta', 'alpha', 'deprecated']).optional(),
     createdAt: z.string().date(),
+    // Human-readable descriptions for each trackable (keyed by trackable ID)
+    trackables: z.record(z.string(), TrackableMetadataZ).optional(),
   })
   .strict();
 


### PR DESCRIPTION
- Extend AdapterMetadata type to support trackable descriptions
- Add generate-adapter-catalog script to aggregate all adapter metadata
- Sync catalog version with package.json version
- Add npm exports for catalog consumption (@absinthelabs/adapters/catalog)
- Update adapter registry to store metadata alongside manifest
- Add GitHub Action workflow for auto-detecting changes and publishing